### PR TITLE
dev: option type

### DIFF
--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -1,19 +1,16 @@
 import { test, expect, describe } from 'bun:test';
-import { Memory, UnknownAddressError, WriteOnceError } from './memory';
-import {
-  MaybeRelocatable,
-  Relocatable,
-  SegmentError,
-} from 'primitives/relocatable';
+import { Memory, WriteOnceError } from './memory';
+import { Relocatable, SegmentError } from 'primitives/relocatable';
 import { Felt } from 'primitives/felt';
+import { None } from 'option-pattern/option';
 
 describe('Memory', () => {
   describe('get', () => {
-    test('should return error if address is not written to', () => {
+    test('should return None if address is not written to', () => {
       const memory = new Memory();
       const address = new Relocatable(0, 0);
-      const result = memory.get(address).unwrapErr();
-      expect(result).toEqual(UnknownAddressError);
+      const result = memory.get(address);
+      expect(result).toEqual(new None());
     });
 
     test('should return the value at the address', () => {

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -5,6 +5,7 @@ import {
   SegmentError,
 } from 'primitives/relocatable';
 import { Uint32, UnsignedInteger } from 'primitives/uint';
+import { None, Option, Some } from 'option-pattern/option';
 
 export class MemoryError extends Error {}
 
@@ -40,12 +41,12 @@ export class Memory {
     return new Ok(true as const);
   }
 
-  get(address: Relocatable): Result<MaybeRelocatable, VMError> {
+  get(address: Relocatable): Option<MaybeRelocatable> {
     const value = this.data.get(address);
     if (value === undefined) {
-      return new Err(UnknownAddressError);
+      return new None();
     }
-    return new Ok(value);
+    return new Some(value);
   }
 
   incrementNumSegments() {

--- a/src/option-pattern/option.test.ts
+++ b/src/option-pattern/option.test.ts
@@ -1,0 +1,51 @@
+import { test, expect, describe } from 'bun:test';
+import { None, NoneError, Some } from './option';
+import { Err, Ok } from 'result-pattern/result';
+
+describe('Option', () => {
+  describe('isSome', () => {
+    test('should return true for Some', () => {
+      const some = new Some(10);
+      expect(some.isSome()).toBeTrue();
+    });
+    test('should return false for None', () => {
+      const none = new None();
+      expect(none.isSome()).toBeFalse();
+    });
+  });
+
+  describe('isNone', () => {
+    test('should return false for Some', () => {
+      const some = new Some(10);
+      expect(some.isNone()).toBeFalse();
+    });
+    test('should return true for None', () => {
+      const none = new None();
+      expect(none.isNone()).toBeTrue();
+    });
+  });
+
+  describe('unwrap', () => {
+    test('should return the inner value', () => {
+      const some = new Some(10);
+      expect(some.unwrap()).toEqual(10);
+    });
+    test('should throw NoneError', () => {
+      const none = new None();
+      expect(() => none.unwrap()).toThrow(
+        new NoneError('Attempted to unwrap a None value')
+      );
+    });
+  });
+
+  describe('ok', () => {
+    test('should return a Result::Ok', () => {
+      const some = new Some(10);
+      expect(some.ok()).toEqual(new Ok(10));
+    });
+    test('should return a Result::Err', () => {
+      const none = new None();
+      expect(none.ok()).toEqual(new Err(new NoneError('Option is none')));
+    });
+  });
+});

--- a/src/option-pattern/option.ts
+++ b/src/option-pattern/option.ts
@@ -1,0 +1,40 @@
+import { Err, Ok } from 'result-pattern/result';
+
+export class Some<T> {
+  private value: T;
+  constructor(value: T) {
+    this.value = value;
+  }
+  isSome(): this is Some<T> {
+    return true;
+  }
+  isNone(): this is never {
+    return false;
+  }
+  unwrap(): T {
+    return this.value;
+  }
+  ok(): Ok<T> {
+    return new Ok(this.value);
+  }
+}
+
+export class NoneError extends Error {}
+
+export class None {
+  constructor() {}
+  isSome(): this is never {
+    return false;
+  }
+  isNone(): this is None {
+    return true;
+  }
+  unwrap(): never {
+    throw new NoneError('Attempted to unwrap a None value');
+  }
+  ok(): Err<NoneError> {
+    return new Err(new NoneError('Option is none'));
+  }
+}
+
+export type Option<T> = Some<T> | None;

--- a/src/result-pattern/result.test.ts
+++ b/src/result-pattern/result.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import { Err, Ok, Result, UnwrapError, VMError } from './result';
+import { Err, Ok, VMError } from './result';
 import { FeltError } from 'primitives/felt';
 
 describe('Result', () => {

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -9,6 +9,10 @@ export const InstructionError = {
   message: 'VMError: VM Instruction must be a Field Element',
 };
 
+export const EndOfInstructionsError = {
+  message: 'VMError: reached end of instructions',
+};
+
 export class VirtualMachine {
   private runContext: RunContext;
   private currentStep: Uint64;
@@ -25,8 +29,8 @@ export class VirtualMachine {
       this.runContext.getPc()
     );
 
-    if (maybeEncodedInstruction.isErr()) {
-      return maybeEncodedInstruction;
+    if (maybeEncodedInstruction.isNone()) {
+      return new Err(EndOfInstructionsError);
     }
 
     const encodedInstruction = maybeEncodedInstruction.unwrap();


### PR DESCRIPTION
Implement the option type in order to avoid returning an error when querying an untouched memory cell. Solves #23.