### PR TITLE
refactor: errors

### DIFF
--- a/src/errors/instruction.ts
+++ b/src/errors/instruction.ts
@@ -5,7 +5,7 @@ export class InstructionError extends Error {}
 export class HighBitSetError extends InstructionError {}
 
 /** Invalid op1 Source */
-export class InvalidOperandOneSource extends InstructionError {}
+export class InvalidOp1Source extends InstructionError {}
 
 /** Invalid PC Update */
 export class InvalidPcUpdate extends InstructionError {}

--- a/src/errors/instruction.ts
+++ b/src/errors/instruction.ts
@@ -1,8 +1,20 @@
+/** Errors related to Instruction methods */
 export class InstructionError extends Error {}
 
-export const HighBitSetError = 'High bit is not zero';
-export const InvalidOperandOneSource = 'Invalid Operand 1 Source';
-export const InvalidPcUpdate = 'Invalid PC Update';
-export const InvalidApUpdate = 'Invalid AP Update';
-export const InvalidOpLogic = 'Invalid Result Logic';
-export const InvalidOpcode = 'Invalid Opcode';
+/** High bit is not zero */
+export class HighBitSetError extends InstructionError {}
+
+/** Invalid op1 Source */
+export class InvalidOperandOneSource extends InstructionError {}
+
+/** Invalid PC Update */
+export class InvalidPcUpdate extends InstructionError {}
+
+/** Invalid AP Update */
+export class InvalidApUpdate extends InstructionError {}
+
+/** Invalid Result Logic */
+export class InvalidOpLogic extends InstructionError {}
+
+/** Invalid Opcode */
+export class InvalidOpcode extends InstructionError {}

--- a/src/errors/memory.ts
+++ b/src/errors/memory.ts
@@ -1,14 +1,20 @@
-import { MaybeRelocatable } from 'primitives/relocatable';
+import { MaybeRelocatable, Relocatable } from 'primitives/relocatable';
 
 export class MemoryError extends Error {}
 
-/** Write existing memory. Can only write to memory once */
+/** Read a different value (`newValue`) than the already constrained value (`oldValue`) at `address` */
 export class InconsistentMemory extends MemoryError {
+  public readonly address: Relocatable;
   public readonly oldValue: MaybeRelocatable;
   public readonly newValue: MaybeRelocatable;
 
-  constructor(oldValue: MaybeRelocatable, newValue: MaybeRelocatable) {
+  constructor(
+    address: Relocatable,
+    oldValue: MaybeRelocatable,
+    newValue: MaybeRelocatable
+  ) {
     super();
+    this.address = address;
     this.oldValue = oldValue;
     this.newValue = newValue;
   }

--- a/src/errors/memory.ts
+++ b/src/errors/memory.ts
@@ -1,9 +1,5 @@
 export class MemoryError extends Error {}
 
-export const UnknownAddressError =
-  'Access memory at unknown or uninitialized address';
 export const WriteOnceError =
   'Write existing memory. Can only write to memory once.';
-export const SegmentIncrementError = 'Error incrementing number of segments';
 export const InstructionError = 'Instruction must be a Field Element';
-export const DeductionError = 'Failed to deduce operands';

--- a/src/errors/memory.ts
+++ b/src/errors/memory.ts
@@ -3,17 +3,16 @@ export class MemoryError extends Error {}
 /** Write existing memory. Can only write to memory once */
 export class WriteOnceError extends MemoryError {}
 
-/** Trying to write on the segment `segment_index`
- * while only `segment_number` are currently defined
+/** Trying to read on a segment that is not accessible (`segmentIndex >= segmentNumber`)
  */
-export class WriteInvalidSegment extends MemoryError {
-  public readonly segment_index: number;
-  public readonly segment_number: number;
+export class SegmentOutOfBounds extends MemoryError {
+  public readonly segmentIndex: number;
+  public readonly segmentNumber: number;
 
   constructor(segment_index: number, segment_number: number) {
     super();
-    this.segment_index = segment_index;
-    this.segment_number = segment_number;
+    this.segmentIndex = segment_index;
+    this.segmentNumber = segment_number;
   }
 }
 

--- a/src/errors/memory.ts
+++ b/src/errors/memory.ts
@@ -1,5 +1,21 @@
 export class MemoryError extends Error {}
 
-export const WriteOnceError =
-  'Write existing memory. Can only write to memory once.';
-export const InstructionError = 'Instruction must be a Field Element';
+/** Write existing memory. Can only write to memory once */
+export class WriteOnceError extends MemoryError {}
+
+/** Trying to write on the segment `segment_index`
+ * while only `segment_number` are currently defined
+ */
+export class WriteInvalidSegment extends MemoryError {
+  public readonly segment_index: number;
+  public readonly segment_number: number;
+
+  constructor(segment_index: number, segment_number: number) {
+    super();
+    this.segment_index = segment_index;
+    this.segment_number = segment_number;
+  }
+}
+
+/** Instruction must be a Field Element */
+export class InstructionError extends MemoryError {}

--- a/src/errors/memory.ts
+++ b/src/errors/memory.ts
@@ -1,10 +1,20 @@
+import { MaybeRelocatable } from 'primitives/relocatable';
+
 export class MemoryError extends Error {}
 
 /** Write existing memory. Can only write to memory once */
-export class WriteOnceError extends MemoryError {}
+export class InconsistentMemory extends MemoryError {
+  public readonly oldValue: MaybeRelocatable;
+  public readonly newValue: MaybeRelocatable;
 
-/** Trying to read on a segment that is not accessible (`segmentIndex >= segmentNumber`)
- */
+  constructor(oldValue: MaybeRelocatable, newValue: MaybeRelocatable) {
+    super();
+    this.oldValue = oldValue;
+    this.newValue = newValue;
+  }
+}
+
+/** Trying to read on a segment that is not accessible (`segmentIndex >= segmentNumber`) */
 export class SegmentOutOfBounds extends MemoryError {
   public readonly segmentIndex: number;
   public readonly segmentNumber: number;

--- a/src/errors/primitives.ts
+++ b/src/errors/primitives.ts
@@ -2,7 +2,6 @@ export class PrimitiveError extends Error {}
 
 // Felt and Relocatable errors
 export const ForbiddenOperation = 'Forbidden operation';
-export const OffsetOverflow = 'Offset overflow';
 export const OffsetUnderflow = 'Offset underflow';
 export const SegmentError = 'Segment error';
 export const OutOfRangeBigInt =

--- a/src/errors/primitives.ts
+++ b/src/errors/primitives.ts
@@ -1,18 +1,28 @@
 export class PrimitiveError extends Error {}
 
 // Felt and Relocatable errors
-export const ForbiddenOperation = 'Forbidden operation';
-export const OffsetUnderflow = 'Offset underflow';
-export const SegmentError = 'Segment error';
-export const OutOfRangeBigInt =
-  'Underlying bigint negative, or greater than Felt.PRIME';
+
+/** Forbidden operation */
+export class ForbiddenOperation extends PrimitiveError {}
+/** Offset underflow */
+export class OffsetUnderflow extends PrimitiveError {}
+/** Segment error */
+export class SegmentError extends PrimitiveError {}
+/** Underlying bigint negative, or greater than Felt.PRIME */
+export class OutOfRangeBigInt extends PrimitiveError {}
+
 // Int16 errors
-export const ByteArrayLengthError = 'Expected a byte array of length 2.';
-export const OutOfRangeNumber = 'Underlying number out of range';
+
+/** Expected a byte array of length 2 */
+export class ByteArrayLengthError extends PrimitiveError {}
+/** Underlying number out of range */
+export class OutOfRangeNumber extends PrimitiveError {}
+
 // Uint errors
-export const Uint16ConversionError =
-  'Cannot convert to Uint16, as underlying number < 0 or > 2^16';
-export const Uint53ConversionError =
-  'Cannot convert to Uint53, as underlying number < 0 or > Number.MAX_SAFE_INTEGER OR is not an integer';
-export const Uint64ConversionError =
-  'Cannot convert to Uint64, as underlying bigint < 0 or > 2^64';
+
+/** Cannot convert to Uint16, as underlying number < 0 or > 2^16 */
+export class Uint16ConversionError extends PrimitiveError {}
+/** Cannot convert to Uint53, as underlying number < 0 or > Number.MAX_SAFE_INTEGER OR is not an integer */
+export class Uint53ConversionError extends PrimitiveError {}
+/** Cannot convert to Uint64, as underlying bigint < 0 or > 2^64 */
+export class Uint64ConversionError extends PrimitiveError {}

--- a/src/errors/virtualMachine.ts
+++ b/src/errors/virtualMachine.ts
@@ -1,15 +1,25 @@
 export class VirtualMachineError extends Error {}
 
-export const EndOfInstructionsError = 'End of instructions';
-export const UnconstrainedResError = 'Result is unconstrained';
-export const DiffAssertValuesError = 'Assert values are different';
-export const InvalidDstOperand = 'Invalid destination operand';
-export const InvalidOp0 = 'Invalid operand 0';
-export const InvalidOp1 = 'Invalid operand 1';
-export const ExpectedRelocatable = 'Expected relocatable';
-export const ExpectedFelt = 'Expected felt';
+/** End of instructions */
+export class EndOfInstructionsError extends VirtualMachineError {}
+/** Result is unconstrained */
+export class UnconstrainedResError extends VirtualMachineError {}
+/** Assert values are different */
+export class DiffAssertValuesError extends VirtualMachineError {}
+/** Invalid destination operand */
+export class InvalidDstOperand extends VirtualMachineError {}
+/** Invalid operand 0 */
+export class InvalidOp0 extends VirtualMachineError {}
+/** Invalid operand 1 */
+export class InvalidOp1 extends VirtualMachineError {}
+/** Expected relocatable */
+export class ExpectedRelocatable extends VirtualMachineError {}
+/** Expected felt */
+export class ExpectedFelt extends VirtualMachineError {}
 
-export const Op1ImmediateOffsetError = 'Op1 immediate offset should be 1';
-export const Op0NotRelocatable =
-  'Op0 is not relocatable. Cannot compute Op1 address';
-export const Op0Undefined = 'Op0 is undefined';
+/** Op1 immediate offset should be 1 */
+export class Op1ImmediateOffsetError extends VirtualMachineError {}
+/** Op0 is not relocatable. Cannot compute Op1 address */
+export class Op0NotRelocatable extends VirtualMachineError {}
+/** Op0 is undefined */
+export class Op0Undefined extends VirtualMachineError {}

--- a/src/errors/virtualMachine.ts
+++ b/src/errors/virtualMachine.ts
@@ -3,14 +3,12 @@ export class VirtualMachineError extends Error {}
 export const EndOfInstructionsError = 'End of instructions';
 export const UnconstrainedResError = 'Result is unconstrained';
 export const DiffAssertValuesError = 'Assert values are different';
-export const InvalidResOperand = 'Invalid result operand';
 export const InvalidDstOperand = 'Invalid destination operand';
 export const InvalidOperand0 = 'Invalid operand 0';
 export const InvalidOperand1 = 'Invalid operand 1';
 export const ExpectedRelocatable = 'Expected relocatable';
 export const ExpectedFelt = 'Expected felt';
 
-export const PCError = 'Cannot increment PC';
 export const Op1ImmediateOffsetError = 'Op1 immediate offset should be 1';
 export const Op0NotRelocatable =
   'Op0 is not relocatable. Cannot compute Op1 address';

--- a/src/errors/virtualMachine.ts
+++ b/src/errors/virtualMachine.ts
@@ -4,8 +4,8 @@ export const EndOfInstructionsError = 'End of instructions';
 export const UnconstrainedResError = 'Result is unconstrained';
 export const DiffAssertValuesError = 'Assert values are different';
 export const InvalidDstOperand = 'Invalid destination operand';
-export const InvalidOperand0 = 'Invalid operand 0';
-export const InvalidOperand1 = 'Invalid operand 1';
+export const InvalidOp0 = 'Invalid operand 0';
+export const InvalidOp1 = 'Invalid operand 1';
 export const ExpectedRelocatable = 'Expected relocatable';
 export const ExpectedFelt = 'Expected felt';
 

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -60,14 +60,14 @@ describe('Memory', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
-      memory.read(address, DATA[0]);
+      memory.assertEq(address, DATA[0]);
 
       expect(memory.get(address)).toEqual(DATA[0]);
     });
     test('should throw SegmentOutOfBounds on access to uninitialized segment', () => {
       const memory = new Memory();
       const address = new Relocatable(1, 10);
-      expect(() => memory.read(address, DATA[0])).toThrow(
+      expect(() => memory.assertEq(address, DATA[0])).toThrow(
         new SegmentOutOfBounds(address.segment, memory.getSegmentNumber())
       );
     });
@@ -75,18 +75,18 @@ describe('Memory', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
-      memory.read(address, DATA[0]);
+      memory.assertEq(address, DATA[0]);
 
-      expect(() => memory.read(address, DATA[0])).not.toThrow();
+      expect(() => memory.assertEq(address, DATA[0])).not.toThrow();
     });
 
     test('should throw InconsistentMemory on memory already constrained by a different value', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
-      memory.read(address, DATA[0]);
+      memory.assertEq(address, DATA[0]);
 
-      expect(() => memory.read(address, DATA[1])).toThrow(
+      expect(() => memory.assertEq(address, DATA[1])).toThrow(
         new InconsistentMemory(address, DATA[0], DATA[1])
       );
     });

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -2,8 +2,7 @@ import { test, expect, describe } from 'bun:test';
 import { Memory } from './memory';
 import { Relocatable } from 'primitives/relocatable';
 import { Felt } from 'primitives/felt';
-import { SegmentError } from 'errors/primitives';
-import { WriteOnceError } from 'errors/memory';
+import { WriteInvalidSegment, WriteOnceError } from 'errors/memory';
 
 describe('Memory', () => {
   describe('get', () => {
@@ -68,7 +67,9 @@ describe('Memory', () => {
     test('should throw SegmentError on uninitialized segment', () => {
       const memory = new Memory();
       const address = new Relocatable(1, 10);
-      expect(() => memory.write(address, DATA[0])).toThrow(SegmentError);
+      expect(() => memory.write(address, DATA[0])).toThrow(
+        new WriteInvalidSegment(address.segment, memory.getSegmentNumber())
+      );
     });
     test('should throw WriteOnceError on memory already written to', () => {
       const memory = new Memory();
@@ -76,7 +77,9 @@ describe('Memory', () => {
       const address = new Relocatable(0, 10);
       memory.write(address, DATA[0]);
 
-      expect(() => memory.write(address, DATA[0])).toThrow(WriteOnceError);
+      expect(() => memory.write(address, DATA[0])).toThrow(
+        new WriteOnceError()
+      );
     });
   });
 });

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -87,7 +87,7 @@ describe('Memory', () => {
       memory.read(address, DATA[0]);
 
       expect(() => memory.read(address, DATA[1])).toThrow(
-        new InconsistentMemory(DATA[0], DATA[1])
+        new InconsistentMemory(address, DATA[0], DATA[1])
       );
     });
   });

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe } from 'bun:test';
 import { Memory } from './memory';
 import { Relocatable } from 'primitives/relocatable';
 import { Felt } from 'primitives/felt';
-import { WriteInvalidSegment, WriteOnceError } from 'errors/memory';
+import { SegmentOutOfBounds, WriteOnceError } from 'errors/memory';
 
 describe('Memory', () => {
   describe('get', () => {
@@ -64,11 +64,11 @@ describe('Memory', () => {
 
       expect(memory.get(address)).toEqual(DATA[0]);
     });
-    test('should throw SegmentError on uninitialized segment', () => {
+    test('should throw SegmentOutOfBounds on access to uninitialized segment', () => {
       const memory = new Memory();
       const address = new Relocatable(1, 10);
       expect(() => memory.write(address, DATA[0])).toThrow(
-        new WriteInvalidSegment(address.segment, memory.getSegmentNumber())
+        new SegmentOutOfBounds(address.segment, memory.getSegmentNumber())
       );
     });
     test('should throw WriteOnceError on memory already written to', () => {

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -55,8 +55,8 @@ describe('Memory', () => {
     });
   });
 
-  describe('read', () => {
-    test('should read a constrained value in the memory at the given address', () => {
+  describe('assertEq', () => {
+    test('should write when the value is undefined', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
@@ -64,14 +64,8 @@ describe('Memory', () => {
 
       expect(memory.get(address)).toEqual(DATA[0]);
     });
-    test('should throw SegmentOutOfBounds on access to uninitialized segment', () => {
-      const memory = new Memory();
-      const address = new Relocatable(1, 10);
-      expect(() => memory.assertEq(address, DATA[0])).toThrow(
-        new SegmentOutOfBounds(address.segment, memory.getSegmentNumber())
-      );
-    });
-    test('should not throw when reading an address twice with the same value', () => {
+
+    test('should not throw when the given value is the one stored', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
@@ -80,7 +74,7 @@ describe('Memory', () => {
       expect(() => memory.assertEq(address, DATA[0])).not.toThrow();
     });
 
-    test('should throw InconsistentMemory on memory already constrained by a different value', () => {
+    test('should throw when the given value is not the one stored', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
@@ -88,6 +82,14 @@ describe('Memory', () => {
 
       expect(() => memory.assertEq(address, DATA[1])).toThrow(
         new InconsistentMemory(address, DATA[0], DATA[1])
+      );
+    });
+
+    test('should throw when the segment is not initialized', () => {
+      const memory = new Memory();
+      const address = new Relocatable(1, 10);
+      expect(() => memory.assertEq(address, DATA[0])).toThrow(
+        new SegmentOutOfBounds(address.segment, memory.getSegmentNumber())
       );
     });
   });

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -6,7 +6,7 @@ import { SegmentOutOfBounds, InconsistentMemory } from 'errors/memory';
 
 describe('Memory', () => {
   describe('get', () => {
-    test('should return undefined if address is not written to', () => {
+    test('should return undefined if address is not constrained yet', () => {
       const memory = new Memory();
       const address = new Relocatable(0, 0);
       const result = memory.get(address);
@@ -55,19 +55,19 @@ describe('Memory', () => {
     });
   });
 
-  describe('write', () => {
-    test('should write a value in the memory at the given address', () => {
+  describe('read', () => {
+    test('should read a constrained value in the memory at the given address', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
-      memory.write(address, DATA[0]);
+      memory.read(address, DATA[0]);
 
       expect(memory.get(address)).toEqual(DATA[0]);
     });
     test('should throw SegmentOutOfBounds on access to uninitialized segment', () => {
       const memory = new Memory();
       const address = new Relocatable(1, 10);
-      expect(() => memory.write(address, DATA[0])).toThrow(
+      expect(() => memory.read(address, DATA[0])).toThrow(
         new SegmentOutOfBounds(address.segment, memory.getSegmentNumber())
       );
     });
@@ -75,18 +75,18 @@ describe('Memory', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
-      memory.write(address, DATA[0]);
+      memory.read(address, DATA[0]);
 
-      expect(() => memory.write(address, DATA[0])).not.toThrow();
+      expect(() => memory.read(address, DATA[0])).not.toThrow();
     });
 
     test('should throw InconsistentMemory on memory already constrained by a different value', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 10);
-      memory.write(address, DATA[0]);
+      memory.read(address, DATA[0]);
 
-      expect(() => memory.write(address, DATA[1])).toThrow(
+      expect(() => memory.read(address, DATA[1])).toThrow(
         new InconsistentMemory(DATA[0], DATA[1])
       );
     });

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -1,5 +1,4 @@
-import { MemoryError, WriteOnceError } from 'errors/memory';
-import { SegmentError } from 'errors/primitives';
+import { WriteInvalidSegment, WriteOnceError } from 'errors/memory';
 import { MaybeRelocatable, Relocatable } from 'primitives/relocatable';
 
 export class Memory {
@@ -32,14 +31,10 @@ export class Memory {
   // the segment size by 1.
   write(address: Relocatable, value: MaybeRelocatable): void {
     if (address.segment >= this.getSegmentNumber()) {
-      throw new MemoryError(
-        `${SegmentError}: trying to insert at segment ${
-          address.segment
-        } while there are only ${this.getSegmentNumber()} segments.`
-      );
+      throw new WriteInvalidSegment(address.segment, this.getSegmentNumber());
     }
     if (this.data[address.segment][address.offset] !== undefined) {
-      throw new MemoryError(WriteOnceError);
+      throw new WriteOnceError();
     }
     this.data[address.segment][address.offset] = value;
   }

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -28,17 +28,10 @@ export class Memory {
   }
 
   /**
-   * Assert that the memory cell at `address` equals `value`.
-   * - If `address` is undefined, the memory cell is replaced by `value` - Happens only once.
-   * - Any further call to `address` with `newValue` will throw if `newValue !== value`.
+   * @param address
+   * @param value
    *
-   * @param address Memory cell
-   * @param value Value to assert at `address`
-   *
-   * NOTE: Cairo memory follows a Nondeterministic-Read-Only model.
-   *
-   * NOTE2: Method equivalent to `insert()` in the rust cairo-vm
-   * and `__setitem__()` in the python cairo-vm
+   * @dev if memory at `address` is undefined, it is set to `value`
    */
   assertEq(address: Relocatable, value: MaybeRelocatable): void {
     const { segment, offset } = address;

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -54,7 +54,7 @@ export class Memory {
     if (currentValue === undefined) {
       this.data[segment][offset] = value;
     } else if (currentValue !== value) {
-      throw new InconsistentMemory(this.data[segment][offset], value);
+      throw new InconsistentMemory(address, this.data[segment][offset], value);
     }
   }
 

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -23,24 +23,24 @@ export class Memory {
 
   setData(address: Relocatable, data: MaybeRelocatable[]): void {
     data.forEach((value, index) => {
-      this.read(address.add(index), value);
+      this.assertEq(address.add(index), value);
     });
   }
 
   /**
-   * Read the value constrained at `address` and check the consistency of `value`
-   * @param address
-   * @param value Value expected to be read at `address`
+   * Assert that the memory cell at `address` equals `value`.
+   * - If `address` is undefined, the memory cell is replaced by `value` - Happens only once.
+   * - Any further call to `address` with `newValue` will throw if `newValue !== value`.
    *
-   * NOTE: Cairo memory is Nondeterministic-Read-Only.
+   * @param address Memory cell
+   * @param value Value to assert at `address`
    *
-   * The VM doesn't actually write to the memory, but the prover does, once.
-   * Memory cell values are constrained as the program is executed:
-   * - If the cell at `address` is `undefined`, then the first call to `read(address, value)`
-   * constrains `address` to `value`
-   * - If the cell at `address` already has a value, it cannot be changed, only read. Further calls `
+   * NOTE: Cairo memory follows a Nondeterministic-Read-Only model.
+   *
+   * NOTE2: Method equivalent to `insert()` in the rust cairo-vm
+   * and `__setitem__()` in the python cairo-vm
    */
-  read(address: Relocatable, value: MaybeRelocatable): void {
+  assertEq(address: Relocatable, value: MaybeRelocatable): void {
     const { segment, offset } = address;
     const segmentNumber = this.getSegmentNumber();
 

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -1,4 +1,4 @@
-import { WriteInvalidSegment, WriteOnceError } from 'errors/memory';
+import { SegmentOutOfBounds, WriteOnceError } from 'errors/memory';
 import { MaybeRelocatable, Relocatable } from 'primitives/relocatable';
 
 export class Memory {
@@ -31,7 +31,7 @@ export class Memory {
   // the segment size by 1.
   write(address: Relocatable, value: MaybeRelocatable): void {
     if (address.segment >= this.getSegmentNumber()) {
-      throw new WriteInvalidSegment(address.segment, this.getSegmentNumber());
+      throw new SegmentOutOfBounds(address.segment, this.getSegmentNumber());
     }
     if (this.data[address.segment][address.offset] !== undefined) {
       throw new WriteOnceError();

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -23,7 +23,7 @@ export class Memory {
 
   setData(address: Relocatable, data: MaybeRelocatable[]): void {
     data.forEach((value, index) => {
-      this.write(address.add(index), value);
+      this.read(address.add(index), value);
     });
   }
 
@@ -40,7 +40,7 @@ export class Memory {
    * constrains `address` to `value`
    * - If the cell at `address` already has a value, it cannot be changed, only read. Further calls `
    */
-  write(address: Relocatable, value: MaybeRelocatable): void {
+  read(address: Relocatable, value: MaybeRelocatable): void {
     const { segment, offset } = address;
     const segmentNumber = this.getSegmentNumber();
 

--- a/src/primitives/felt.test.ts
+++ b/src/primitives/felt.test.ts
@@ -4,23 +4,15 @@ import { Felt } from './felt';
 describe('Felt', () => {
   describe('constructor', () => {
     test.each([
-      [-10n, new Felt(Felt.PRIME - 10n)],
-      [-15n, new Felt(Felt.PRIME - 15n)],
-      [-(Felt.PRIME + 10n), new Felt(Felt.PRIME - 10n)],
-    ])(
-      'should properly initialize a Felt with a negative bigint as parameter',
-      (parameter: bigint, result: Felt) => {
-        expect(new Felt(parameter)).toStrictEqual(result);
-      }
-    );
-
-    test.each([
       [Felt.PRIME, new Felt(0n)],
       [Felt.PRIME + 10n, new Felt(10n)],
       [Felt.PRIME + 15n, new Felt(15n)],
+      [-10n, new Felt(Felt.PRIME - 10n)],
+      [-15n, new Felt(Felt.PRIME - 15n)],
       [Felt.PRIME * 2n + 10n, new Felt(10n)],
+      [-(Felt.PRIME + 10n), new Felt(Felt.PRIME - 10n)],
     ])(
-      'should initialize a Felt with r = x % PRIME for x a bigint equal to q*PRIME + r',
+      'should properly initialize a Felt with any bigint value as parameter',
       (parameter: bigint, result: Felt) => {
         expect(new Felt(parameter)).toStrictEqual(result);
       }

--- a/src/primitives/felt.test.ts
+++ b/src/primitives/felt.test.ts
@@ -1,15 +1,24 @@
 import { test, expect, describe } from 'bun:test';
 import { Felt } from './felt';
-import { OutOfRangeBigInt } from 'errors/primitives';
 
 describe('Felt', () => {
   describe('constructor', () => {
-    test('should throw if initializing a felt with a negative inner', () => {
-      expect(() => new Felt(-10n)).toThrow(new OutOfRangeBigInt());
+    test('should properly initialize a Felt with a negative bigint as parameter', () => {
+      const negativeUnderPrime = -(Felt.PRIME + 10n);
+      const negativeEvenUnderPrime = -(Felt.PRIME + Felt.PRIME + 15n);
+      expect(new Felt(negativeUnderPrime)).toStrictEqual(
+        new Felt(Felt.PRIME - 10n)
+      );
+      expect(new Felt(negativeEvenUnderPrime)).toStrictEqual(
+        new Felt(Felt.PRIME - 15n)
+      );
     });
-    test('should throw a FeltError when initializing with a BigInt larger than PRIME', () => {
+    test('should initialize a Felt with r = x % PRIME for x a bigint equal to q*PRIME + r', () => {
       const biggerThanPrime = Felt.PRIME + 1n;
-      expect(() => new Felt(biggerThanPrime)).toThrow(new OutOfRangeBigInt());
+      const evenBiggerThanPrime = Felt.PRIME + Felt.PRIME + 1n;
+      expect(new Felt(biggerThanPrime)).toStrictEqual(new Felt(1n));
+      expect(new Felt(evenBiggerThanPrime)).toStrictEqual(new Felt(1n));
+      expect(new Felt(Felt.PRIME)).toStrictEqual(new Felt(0n));
     });
   });
 

--- a/src/primitives/felt.test.ts
+++ b/src/primitives/felt.test.ts
@@ -6,15 +6,11 @@ import { Relocatable } from './relocatable';
 describe('Felt', () => {
   describe('constructor', () => {
     test('should throw if initializing a felt with a negative inner', () => {
-      expect(() => new Felt(-10n)).toThrow(
-        new PrimitiveError(OutOfRangeBigInt)
-      );
+      expect(() => new Felt(-10n)).toThrow(new OutOfRangeBigInt());
     });
     test('should throw a FeltError when initializing with a BigInt larger than PRIME', () => {
       const biggerThanPrime = Felt.PRIME + 1n;
-      expect(() => new Felt(biggerThanPrime)).toThrow(
-        new PrimitiveError(OutOfRangeBigInt)
-      );
+      expect(() => new Felt(biggerThanPrime)).toThrow(new OutOfRangeBigInt());
     });
   });
 

--- a/src/primitives/felt.test.ts
+++ b/src/primitives/felt.test.ts
@@ -3,23 +3,28 @@ import { Felt } from './felt';
 
 describe('Felt', () => {
   describe('constructor', () => {
-    test('should properly initialize a Felt with a negative bigint as parameter', () => {
-      const negativeUnderPrime = -(Felt.PRIME + 10n);
-      const negativeEvenUnderPrime = -(Felt.PRIME + Felt.PRIME + 15n);
-      expect(new Felt(negativeUnderPrime)).toStrictEqual(
-        new Felt(Felt.PRIME - 10n)
-      );
-      expect(new Felt(negativeEvenUnderPrime)).toStrictEqual(
-        new Felt(Felt.PRIME - 15n)
-      );
-    });
-    test('should initialize a Felt with r = x % PRIME for x a bigint equal to q*PRIME + r', () => {
-      const biggerThanPrime = Felt.PRIME + 1n;
-      const evenBiggerThanPrime = Felt.PRIME + Felt.PRIME + 1n;
-      expect(new Felt(biggerThanPrime)).toStrictEqual(new Felt(1n));
-      expect(new Felt(evenBiggerThanPrime)).toStrictEqual(new Felt(1n));
-      expect(new Felt(Felt.PRIME)).toStrictEqual(new Felt(0n));
-    });
+    test.each([
+      [-10n, new Felt(Felt.PRIME - 10n)],
+      [-15n, new Felt(Felt.PRIME - 15n)],
+      [-(Felt.PRIME + 10n), new Felt(Felt.PRIME - 10n)],
+    ])(
+      'should properly initialize a Felt with a negative bigint as parameter',
+      (parameter: bigint, result: Felt) => {
+        expect(new Felt(parameter)).toStrictEqual(result);
+      }
+    );
+
+    test.each([
+      [Felt.PRIME, new Felt(0n)],
+      [Felt.PRIME + 10n, new Felt(10n)],
+      [Felt.PRIME + 15n, new Felt(15n)],
+      [Felt.PRIME * 2n + 10n, new Felt(10n)],
+    ])(
+      'should initialize a Felt with r = x % PRIME for x a bigint equal to q*PRIME + r',
+      (parameter: bigint, result: Felt) => {
+        expect(new Felt(parameter)).toStrictEqual(result);
+      }
+    );
   });
 
   describe('conversions', () => {

--- a/src/primitives/felt.test.ts
+++ b/src/primitives/felt.test.ts
@@ -1,7 +1,6 @@
 import { test, expect, describe } from 'bun:test';
 import { Felt } from './felt';
-import { OutOfRangeBigInt, PrimitiveError } from 'errors/primitives';
-import { Relocatable } from './relocatable';
+import { OutOfRangeBigInt } from 'errors/primitives';
 
 describe('Felt', () => {
   describe('constructor', () => {

--- a/src/primitives/felt.ts
+++ b/src/primitives/felt.ts
@@ -8,17 +8,16 @@ export class Felt {
     0x800000000000011000000000000000000000000000000000000000000000001n;
   static ZERO: Felt = new Felt(0n);
   constructor(_inner: bigint) {
-    if (_inner < 0n || _inner > Felt.PRIME) {
-      throw new OutOfRangeBigInt();
-    }
-    this.inner = _inner;
+    while (_inner < 0n) _inner += Felt.PRIME;
+    this.inner = _inner % Felt.PRIME;
   }
 
   add(other: MaybeRelocatable): Felt {
     if (!(other instanceof Felt)) {
       throw new ForbiddenOperation();
     }
-    return new Felt((this.inner + other.inner) % Felt.PRIME);
+
+    return new Felt(this.inner + other.inner);
   }
 
   sub(other: MaybeRelocatable): Felt {
@@ -26,32 +25,30 @@ export class Felt {
       throw new ForbiddenOperation();
     }
 
-    let result = this.inner - other.inner;
-    if (result < 0n) {
-      result += Felt.PRIME;
-    }
-    return new Felt(result);
+    return new Felt(this.inner - other.inner);
   }
 
   mul(other: MaybeRelocatable): Felt {
     if (!(other instanceof Felt)) {
       throw new ForbiddenOperation();
     }
-    return new Felt((this.inner * other.inner) % Felt.PRIME);
+
+    return new Felt(this.inner * other.inner);
   }
 
   div(other: MaybeRelocatable): Felt {
     if (!(other instanceof Felt) || other.inner === 0n) {
       throw new ForbiddenOperation();
     }
-    let result = this.inner / other.inner;
-    return new Felt(result);
+
+    return new Felt(this.inner / other.inner);
   }
 
   eq(other: MaybeRelocatable): boolean {
     if (other instanceof Relocatable) {
       return false;
     }
+
     return this.inner == other.inner;
   }
 

--- a/src/primitives/felt.ts
+++ b/src/primitives/felt.ts
@@ -13,21 +13,21 @@ export class Felt {
   static ZERO: Felt = new Felt(0n);
   constructor(_inner: bigint) {
     if (_inner < 0n || _inner > Felt.PRIME) {
-      throw new PrimitiveError(OutOfRangeBigInt);
+      throw new OutOfRangeBigInt();
     }
     this.inner = _inner;
   }
 
   add(other: MaybeRelocatable): Felt {
     if (!(other instanceof Felt)) {
-      throw new PrimitiveError(ForbiddenOperation);
+      throw new ForbiddenOperation();
     }
     return new Felt((this.inner + other.inner) % Felt.PRIME);
   }
 
   sub(other: MaybeRelocatable): Felt {
     if (!(other instanceof Felt)) {
-      throw new PrimitiveError(ForbiddenOperation);
+      throw new ForbiddenOperation();
     }
 
     let result = this.inner - other.inner;
@@ -39,14 +39,14 @@ export class Felt {
 
   mul(other: MaybeRelocatable): Felt {
     if (!(other instanceof Felt)) {
-      throw new PrimitiveError(ForbiddenOperation);
+      throw new ForbiddenOperation();
     }
     return new Felt((this.inner * other.inner) % Felt.PRIME);
   }
 
   div(other: MaybeRelocatable): Felt {
     if (!(other instanceof Felt) || other.inner === 0n) {
-      throw new PrimitiveError(ForbiddenOperation);
+      throw new ForbiddenOperation();
     }
     let result = this.inner / other.inner;
     return new Felt(result);

--- a/src/primitives/felt.ts
+++ b/src/primitives/felt.ts
@@ -8,7 +8,9 @@ export class Felt {
     0x800000000000011000000000000000000000000000000000000000000000001n;
   static ZERO: Felt = new Felt(0n);
   constructor(_inner: bigint) {
-    while (_inner < 0n) _inner += Felt.PRIME;
+    if (_inner < 0n) {
+      _inner = (_inner % Felt.PRIME) + Felt.PRIME;
+    }
     this.inner = _inner % Felt.PRIME;
   }
 

--- a/src/primitives/felt.ts
+++ b/src/primitives/felt.ts
@@ -1,10 +1,6 @@
 import { MaybeRelocatable, Relocatable } from './relocatable';
 
-import {
-  ForbiddenOperation,
-  OutOfRangeBigInt,
-  PrimitiveError,
-} from 'errors/primitives';
+import { ForbiddenOperation, OutOfRangeBigInt } from 'errors/primitives';
 
 export class Felt {
   private inner: bigint;

--- a/src/primitives/relocatable.test.ts
+++ b/src/primitives/relocatable.test.ts
@@ -29,13 +29,13 @@ describe('Relocatable', () => {
     test('should throw an error OffsetUnderflow when offset goes below zero', () => {
       const a = new Relocatable(1, 2);
       const b = new Relocatable(1, 3);
-      expect(() => a.sub(b)).toThrow(new PrimitiveError(OffsetUnderflow));
+      expect(() => a.sub(b)).toThrow(new OffsetUnderflow());
     });
 
     test('should throw an error SegmentError when segments are different', () => {
       const a = new Relocatable(1, 10);
       const b = new Relocatable(2, 5);
-      expect(() => a.sub(b)).toThrow(new PrimitiveError(SegmentError));
+      expect(() => a.sub(b)).toThrow(new SegmentError());
     });
 
     test('should subtract a Felt from a Relocatable', () => {
@@ -49,9 +49,7 @@ describe('Relocatable', () => {
     test('should throw an error OffsetUnderflow when subtracting a larger Felt', () => {
       const relocatable = new Relocatable(0, 5);
       const felt = new Felt(10n);
-      expect(() => relocatable.sub(felt)).toThrow(
-        new PrimitiveError(OffsetUnderflow)
-      );
+      expect(() => relocatable.sub(felt)).toThrow(new OffsetUnderflow());
     });
 
     test('should subtract a Relocatable', () => {
@@ -82,7 +80,7 @@ describe('Relocatable', () => {
     test('should throw an error ForbiddenOperation when adding an incompatible MaybeRelocatable', () => {
       const a = new Relocatable(0, 10);
       const b = new Relocatable(0, 5);
-      expect(() => a.add(b)).toThrow(new PrimitiveError(ForbiddenOperation));
+      expect(() => a.add(b)).toThrow(new ForbiddenOperation());
     });
     test('should add a Felt to a Relocatable', () => {
       const relocatable = new Relocatable(0, 5);

--- a/src/primitives/relocatable.test.ts
+++ b/src/primitives/relocatable.test.ts
@@ -1,11 +1,9 @@
 import { test, expect, describe } from 'bun:test';
 import { Felt } from './felt';
 import { Relocatable, MemoryPointer, ProgramCounter } from './relocatable';
-import { UnsignedInteger } from './uint';
 import {
   ForbiddenOperation,
   OffsetUnderflow,
-  PrimitiveError,
   SegmentError,
 } from 'errors/primitives';
 

--- a/src/primitives/relocatable.ts
+++ b/src/primitives/relocatable.ts
@@ -2,7 +2,6 @@ import { Felt } from './felt';
 import {
   ForbiddenOperation,
   OffsetUnderflow,
-  PrimitiveError,
   SegmentError,
 } from 'errors/primitives';
 

--- a/src/primitives/relocatable.ts
+++ b/src/primitives/relocatable.ts
@@ -30,7 +30,7 @@ export class Relocatable {
     }
 
     if (other instanceof Relocatable) {
-      throw new PrimitiveError(ForbiddenOperation);
+      throw new ForbiddenOperation();
     }
 
     return new Relocatable(this.segment, this.offset + other);
@@ -45,25 +45,25 @@ export class Relocatable {
       const delta = Number(other);
 
       if (this.offset < delta) {
-        throw new PrimitiveError(OffsetUnderflow);
+        throw new OffsetUnderflow();
       }
       return new Relocatable(this.segment, this.offset - delta);
     }
 
     if (other instanceof Relocatable) {
       if (this.offset < other.offset) {
-        throw new PrimitiveError(OffsetUnderflow);
+        throw new OffsetUnderflow();
       }
 
       if (this.segment !== other.segment) {
-        throw new PrimitiveError(SegmentError);
+        throw new SegmentError();
       }
 
       return new Felt(BigInt(this.offset - other.offset));
     }
 
     if (this.offset < other) {
-      throw new PrimitiveError(OffsetUnderflow);
+      throw new OffsetUnderflow();
     }
 
     return new Relocatable(this.segment, this.offset - other);

--- a/src/vm/instruction.test.ts
+++ b/src/vm/instruction.test.ts
@@ -5,7 +5,7 @@ import { Instruction } from './instruction';
 import {
   HighBitSetError,
   InvalidApUpdate,
-  InvalidOperandOneSource,
+  InvalidOp1Source,
   InvalidOpcode,
   InvalidPcUpdate,
   InvalidOpLogic,
@@ -19,9 +19,9 @@ describe('Instruction', () => {
       );
     });
 
-    test('should throw an error InvalidOperandOneSource', () => {
+    test('should throw an error InvalidOp1Source', () => {
       expect(() => Instruction.decodeInstruction(0x294f800080008000n)).toThrow(
-        new InvalidOperandOneSource()
+        new InvalidOp1Source()
       );
     });
 

--- a/src/vm/instruction.test.ts
+++ b/src/vm/instruction.test.ts
@@ -4,7 +4,6 @@ import { Instruction } from './instruction';
 
 import {
   HighBitSetError,
-  InstructionError,
   InvalidApUpdate,
   InvalidOperandOneSource,
   InvalidOpcode,
@@ -16,37 +15,37 @@ describe('Instruction', () => {
   describe('decodeInstruction', () => {
     test('should throw an error HighBitSetError', () => {
       expect(() => Instruction.decodeInstruction(0x94a7800080008000n)).toThrow(
-        new InstructionError(HighBitSetError)
+        new HighBitSetError()
       );
     });
 
     test('should throw an error InvalidOperandOneSource', () => {
       expect(() => Instruction.decodeInstruction(0x294f800080008000n)).toThrow(
-        new InstructionError(InvalidOperandOneSource)
+        new InvalidOperandOneSource()
       );
     });
 
     test('should throw an error InvalidPcUpdate', () => {
       expect(() => Instruction.decodeInstruction(0x29a8800080008000n)).toThrow(
-        new InstructionError(InvalidPcUpdate)
+        new InvalidPcUpdate()
       );
     });
 
     test('should throw an error InvalidOpLogic', () => {
       expect(() => Instruction.decodeInstruction(0x2968800080008000n)).toThrow(
-        new InstructionError(InvalidOpLogic)
+        new InvalidOpLogic()
       );
     });
 
     test('should throw an error InvalidOpcode', () => {
       expect(() => Instruction.decodeInstruction(0x3948800080008000n)).toThrow(
-        new InstructionError(InvalidOpcode)
+        new InvalidOpcode()
       );
     });
 
     test('should throw an error with InvalidApUpdate', () => {
       expect(() => Instruction.decodeInstruction(0x2d48800080008000n)).toThrow(
-        new InstructionError(InvalidApUpdate)
+        new InvalidApUpdate()
       );
     });
 

--- a/src/vm/instruction.ts
+++ b/src/vm/instruction.ts
@@ -3,7 +3,6 @@
 // representing the first one with this struct is enough.
 
 import {
-  InstructionError,
   HighBitSetError,
   InvalidApUpdate,
   InvalidOperandOneSource,
@@ -127,7 +126,7 @@ export class Instruction {
     // INVARIANT: The high bit of the encoded instruction must be 0
     const highBit = 1n << 63n;
     if ((highBit & encodedInstruction) !== 0n) {
-      throw new InstructionError(HighBitSetError);
+      throw new HighBitSetError();
     }
 
     // Structure of the 48 first bits of an encoded instruction:
@@ -217,7 +216,7 @@ export class Instruction {
         Op1Source = 'ap';
         break;
       default:
-        throw new InstructionError(InvalidOperandOneSource);
+        throw new InvalidOperandOneSource();
     }
 
     const targetPcUpdate = (flags & pcUpdateMask) >> pcUpdateOff;
@@ -240,7 +239,7 @@ export class Instruction {
         pcUpdate = 'res != 0 ? pc = op1 : pc += instruction_size';
         break;
       default:
-        throw new InstructionError(InvalidPcUpdate);
+        throw new InvalidPcUpdate();
     }
 
     const targetOpLogic = (flags & opLogicMask) >> opLogicOff;
@@ -264,7 +263,7 @@ export class Instruction {
         opLogic = 'op0 * op1';
         break;
       default:
-        throw new InstructionError(InvalidOpLogic);
+        throw new InvalidOpLogic();
     }
 
     const targetOpcode = (flags & opcodeMask) >> opcodeOff;
@@ -287,7 +286,7 @@ export class Instruction {
         opcode = 'assert_eq';
         break;
       default:
-        throw new InstructionError(InvalidOpcode);
+        throw new InvalidOpcode();
     }
 
     const targetApUpdate = (flags & apUpdateMask) >> apUpdateOff;
@@ -309,7 +308,7 @@ export class Instruction {
         apUpdate = 'ap++';
         break;
       default:
-        throw new InstructionError(InvalidApUpdate);
+        throw new InvalidApUpdate();
     }
 
     let fpUpdate: FpUpdate;

--- a/src/vm/instruction.ts
+++ b/src/vm/instruction.ts
@@ -5,7 +5,7 @@
 import {
   HighBitSetError,
   InvalidApUpdate,
-  InvalidOperandOneSource,
+  InvalidOp1Source,
   InvalidOpcode,
   InvalidPcUpdate,
   InvalidOpLogic,
@@ -216,7 +216,7 @@ export class Instruction {
         Op1Source = 'ap';
         break;
       default:
-        throw new InvalidOperandOneSource();
+        throw new InvalidOp1Source();
     }
 
     const targetPcUpdate = (flags & pcUpdateMask) >> pcUpdateOff;

--- a/src/vm/virtualMachine.test.ts
+++ b/src/vm/virtualMachine.test.ts
@@ -269,7 +269,7 @@ describe('VirtualMachine', () => {
       const op1 = new Relocatable(1, 2);
 
       expect(() => vm.computeRes(instruction, op0, op1)).toThrow(
-        new VirtualMachineError(ForbiddenOperation)
+        new ForbiddenOperation()
       );
     });
     test('should deduce res with res logic mul with op0 and op1 felts', () => {

--- a/src/vm/virtualMachine.test.ts
+++ b/src/vm/virtualMachine.test.ts
@@ -16,7 +16,7 @@ import {
   ExpectedFelt,
   ExpectedRelocatable,
   InvalidDstOperand,
-  InvalidOperand0,
+  InvalidOp0,
   UnconstrainedResError,
   VirtualMachineError,
   Op0NotRelocatable,
@@ -442,7 +442,7 @@ describe('VirtualMachine', () => {
         new VirtualMachineError(DiffAssertValuesError)
       );
     });
-    test('should throw InvalidOperand0 on call opcode and pc != op0', () => {
+    test('should throw InvalidOp0 on call opcode and pc != op0', () => {
       const instruction: Instruction = new Instruction(
         1,
         2,
@@ -467,7 +467,7 @@ describe('VirtualMachine', () => {
       const vm = new VirtualMachine();
 
       expect(() => vm.opcodeAssertion(instruction, operands)).toThrow(
-        new VirtualMachineError(InvalidOperand0)
+        new VirtualMachineError(InvalidOp0)
       );
     });
     test('should throw InvalidDstError on call opcode and fp != dst', () => {

--- a/src/vm/virtualMachine.test.ts
+++ b/src/vm/virtualMachine.test.ts
@@ -1,12 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import {
-  ApUpdate,
-  FpUpdate,
-  Instruction,
-  Opcode,
-  PcUpdate,
-  OpLogic,
-} from './instruction';
+import { Instruction, Opcode, OpLogic } from './instruction';
 import { Operands, VirtualMachine } from './virtualMachine';
 import { Relocatable } from 'primitives/relocatable';
 import { Felt } from 'primitives/felt';
@@ -18,7 +11,6 @@ import {
   InvalidDstOperand,
   InvalidOp0,
   UnconstrainedResError,
-  VirtualMachineError,
   Op0NotRelocatable,
   Op0Undefined,
   Op1ImmediateOffsetError,

--- a/src/vm/virtualMachine.test.ts
+++ b/src/vm/virtualMachine.test.ts
@@ -294,7 +294,7 @@ describe('VirtualMachine', () => {
       const op1 = new Relocatable(1, 2);
 
       expect(() => vm.computeRes(instruction, op0, op1)).toThrow(
-        new VirtualMachineError(ExpectedFelt)
+        new ExpectedFelt()
       );
     });
     test('should return undefined with res logic unconstrained', () => {
@@ -383,7 +383,7 @@ describe('VirtualMachine', () => {
       const vm = new VirtualMachine();
 
       expect(() => vm.opcodeAssertion(instruction, operands)).toThrow(
-        new VirtualMachineError(UnconstrainedResError)
+        new UnconstrainedResError()
       );
     });
     test('should throw DiffAssertError on assert eq opcode and res != dst felts', () => {
@@ -411,7 +411,7 @@ describe('VirtualMachine', () => {
       const vm = new VirtualMachine();
 
       expect(() => vm.opcodeAssertion(instruction, operands)).toThrow(
-        new VirtualMachineError(DiffAssertValuesError)
+        new DiffAssertValuesError()
       );
     });
     test('should throw DiffAssertError on assert eq opcode and res != dst relocatables', () => {
@@ -439,7 +439,7 @@ describe('VirtualMachine', () => {
       const vm = new VirtualMachine();
 
       expect(() => vm.opcodeAssertion(instruction, operands)).toThrow(
-        new VirtualMachineError(DiffAssertValuesError)
+        new DiffAssertValuesError()
       );
     });
     test('should throw InvalidOp0 on call opcode and pc != op0', () => {
@@ -467,7 +467,7 @@ describe('VirtualMachine', () => {
       const vm = new VirtualMachine();
 
       expect(() => vm.opcodeAssertion(instruction, operands)).toThrow(
-        new VirtualMachineError(InvalidOp0)
+        new InvalidOp0()
       );
     });
     test('should throw InvalidDstError on call opcode and fp != dst', () => {
@@ -495,7 +495,7 @@ describe('VirtualMachine', () => {
       const vm = new VirtualMachine();
 
       expect(() => vm.opcodeAssertion(instruction, operands)).toThrow(
-        new VirtualMachineError(InvalidDstOperand)
+        new InvalidDstOperand()
       );
     });
   });
@@ -608,7 +608,7 @@ describe('VirtualMachine', () => {
       };
 
       expect(() => vm.updatePc(instruction, operands)).toThrow(
-        new VirtualMachineError(ExpectedRelocatable)
+        new ExpectedRelocatable()
       );
     });
     test('jmp without res', () => {
@@ -636,7 +636,7 @@ describe('VirtualMachine', () => {
       };
 
       expect(() => vm.updatePc(instruction, operands)).toThrow(
-        new VirtualMachineError(UnconstrainedResError)
+        new UnconstrainedResError()
       );
     });
     test('jmp rel res felt', () => {
@@ -691,7 +691,7 @@ describe('VirtualMachine', () => {
       };
 
       expect(() => vm.updatePc(instruction, operands)).toThrow(
-        new VirtualMachineError(ExpectedFelt)
+        new ExpectedFelt()
       );
     });
     test('jmp rel res relocatable', () => {
@@ -719,7 +719,7 @@ describe('VirtualMachine', () => {
       };
 
       expect(() => vm.updatePc(instruction, operands)).toThrow(
-        new VirtualMachineError(UnconstrainedResError)
+        new UnconstrainedResError()
       );
     });
     test('jnz des is zero no imm', () => {
@@ -825,7 +825,7 @@ describe('VirtualMachine', () => {
       };
 
       expect(() => vm.updatePc(instruction, operands)).toThrow(
-        new VirtualMachineError(ExpectedFelt)
+        new ExpectedFelt()
       );
     });
   });
@@ -1080,7 +1080,7 @@ describe('VirtualMachine', () => {
       };
 
       expect(() => vm.updateAp(instruction, operands)).toThrow(
-        new VirtualMachineError(ExpectedFelt)
+        new ExpectedFelt()
       );
     });
     test('add no res', () => {
@@ -1108,7 +1108,7 @@ describe('VirtualMachine', () => {
       };
 
       expect(() => vm.updateAp(instruction, operands)).toThrow(
-        new VirtualMachineError(UnconstrainedResError)
+        new UnconstrainedResError()
       );
     });
   });
@@ -1223,7 +1223,7 @@ describe('VirtualMachine', () => {
       vm.setRegisters(4, 5, 6);
 
       expect(() => vm.computeOp1Address('pc', 2, undefined)).toThrow(
-        new VirtualMachineError(Op1ImmediateOffsetError)
+        new Op1ImmediateOffsetError()
       );
     });
 
@@ -1242,7 +1242,7 @@ describe('VirtualMachine', () => {
       vm.setRegisters(4, 5, 6);
 
       expect(() => vm.computeOp1Address('op0', 1, new Felt(7n))).toThrow(
-        new VirtualMachineError(Op0NotRelocatable)
+        new Op0NotRelocatable()
       );
     });
 
@@ -1251,7 +1251,7 @@ describe('VirtualMachine', () => {
       vm.setRegisters(4, 5, 6);
 
       expect(() => vm.computeOp1Address('op0', 1, undefined)).toThrow(
-        new VirtualMachineError(Op0Undefined)
+        new Op0Undefined()
       );
     });
   });

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -112,7 +112,7 @@ export class VirtualMachine {
     }
 
     if (!(maybeEncodedInstruction instanceof Felt)) {
-      throw new VirtualMachineError(InstructionError);
+      throw new InstructionError();
     }
 
     const encodedInstruction = maybeEncodedInstruction.toBigInt();

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -2,7 +2,7 @@ import {
   ExpectedFelt,
   ExpectedRelocatable,
   InvalidDstOperand,
-  InvalidOperand1,
+  InvalidOp1,
   UnconstrainedResError,
   VirtualMachineError,
   Op0NotRelocatable,
@@ -17,7 +17,7 @@ import { InstructionError } from 'errors/memory';
 import {
   DiffAssertValuesError,
   EndOfInstructionsError,
-  InvalidOperand0,
+  InvalidOp0,
 } from 'errors/virtualMachine';
 import { Memory } from 'memory/memory';
 import { ProgramCounter, MemoryPointer } from 'primitives/relocatable';
@@ -391,7 +391,7 @@ export class VirtualMachine {
           this.incrementPc(instruction.size());
         } else {
           if (operands.op1 === undefined) {
-            throw new VirtualMachineError(InvalidOperand1);
+            throw new VirtualMachineError(InvalidOp1);
           }
           if (!Felt.isFelt(operands.op1)) {
             throw new VirtualMachineError(ExpectedFelt);
@@ -474,7 +474,7 @@ export class VirtualMachine {
       case 'call':
         const nextPc = this.pc.add(instruction.size());
         if (operands.op0 === undefined || !nextPc.eq(operands.op0)) {
-          throw new VirtualMachineError(InvalidOperand0);
+          throw new VirtualMachineError(InvalidOp0);
         }
         if (this.fp !== operands.dst) {
           throw new VirtualMachineError(InvalidDstOperand);

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -4,13 +4,12 @@ import {
   InvalidDstOperand,
   InvalidOp1,
   UnconstrainedResError,
-  VirtualMachineError,
   Op0NotRelocatable,
   Op0Undefined,
   Op1ImmediateOffsetError,
 } from 'errors/virtualMachine';
 import { Felt } from 'primitives/felt';
-import { Instruction, Opcode, PcUpdate, OpLogic } from './instruction';
+import { Instruction } from './instruction';
 import { MaybeRelocatable, Relocatable } from 'primitives/relocatable';
 import { InstructionError } from 'errors/memory';
 

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -169,7 +169,7 @@ export class VirtualMachine {
       const deducedOp0 = this.deduceOp0(instruction, dst, op1);
 
       if (deducedOp0 !== undefined) {
-        this.memory.write(op0Addr, deducedOp0);
+        this.memory.read(op0Addr, deducedOp0);
       }
       op0 = deducedOp0;
     }
@@ -181,7 +181,7 @@ export class VirtualMachine {
       const deducedOp1 = this.deduceOp1(instruction, dst, op0);
 
       if (deducedOp1 !== undefined) {
-        this.memory.write(op1Addr, deducedOp1);
+        this.memory.read(op1Addr, deducedOp1);
       }
     }
 
@@ -201,7 +201,7 @@ export class VirtualMachine {
       const deducedDst = this.deduceDst(instruction, res);
 
       if (deducedDst !== undefined) {
-        this.memory.write(dstAddr, deducedDst);
+        this.memory.read(dstAddr, deducedDst);
       }
       dst = deducedDst;
     }

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -169,7 +169,7 @@ export class VirtualMachine {
       const deducedOp0 = this.deduceOp0(instruction, dst, op1);
 
       if (deducedOp0 !== undefined) {
-        this.memory.read(op0Addr, deducedOp0);
+        this.memory.assertEq(op0Addr, deducedOp0);
       }
       op0 = deducedOp0;
     }
@@ -181,7 +181,7 @@ export class VirtualMachine {
       const deducedOp1 = this.deduceOp1(instruction, dst, op0);
 
       if (deducedOp1 !== undefined) {
-        this.memory.read(op1Addr, deducedOp1);
+        this.memory.assertEq(op1Addr, deducedOp1);
       }
     }
 
@@ -201,7 +201,7 @@ export class VirtualMachine {
       const deducedDst = this.deduceDst(instruction, res);
 
       if (deducedDst !== undefined) {
-        this.memory.read(dstAddr, deducedDst);
+        this.memory.assertEq(dstAddr, deducedDst);
       }
       dst = deducedDst;
     }

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -85,18 +85,18 @@ export class VirtualMachine {
         if (op1Offset == 1) {
           baseAddr = this.pc;
         } else {
-          throw new VirtualMachineError(Op1ImmediateOffsetError);
+          throw new Op1ImmediateOffsetError();
         }
         break;
       case 'op0':
         // In case of operand 0 as the source, we have to check that
         // operand 0 is not undefined.
         if (op0 === undefined) {
-          throw new VirtualMachineError(Op0Undefined);
+          throw new Op0Undefined();
         }
 
         if (!Relocatable.isRelocatable(op0)) {
-          throw new VirtualMachineError(Op0NotRelocatable);
+          throw new Op0NotRelocatable();
         }
         baseAddr = op0;
     }
@@ -108,7 +108,7 @@ export class VirtualMachine {
   step(): void {
     const maybeEncodedInstruction = this.memory.get(this.pc);
     if (maybeEncodedInstruction === undefined) {
-      throw new VirtualMachineError(EndOfInstructionsError);
+      throw new EndOfInstructionsError();
     }
 
     if (!(maybeEncodedInstruction instanceof Felt)) {
@@ -314,7 +314,7 @@ export class VirtualMachine {
         return op0.add(op1);
       case 'op0 * op1':
         if (!Felt.isFelt(op0)) {
-          throw new VirtualMachineError(ExpectedFelt);
+          throw new ExpectedFelt();
         }
         return op0.mul(op1);
       case 'unconstrained':
@@ -361,10 +361,10 @@ export class VirtualMachine {
       // result.
       case 'pc = res':
         if (operands.res === undefined) {
-          throw new VirtualMachineError(UnconstrainedResError);
+          throw new UnconstrainedResError();
         }
         if (!Relocatable.isRelocatable(operands.res)) {
-          throw new VirtualMachineError(ExpectedRelocatable);
+          throw new ExpectedRelocatable();
         }
         this.pc = operands.res;
         break;
@@ -372,11 +372,11 @@ export class VirtualMachine {
       // to the pc.
       case 'pc = pc + res':
         if (operands.res === undefined) {
-          throw new VirtualMachineError(UnconstrainedResError);
+          throw new UnconstrainedResError();
         }
 
         if (!Felt.isFelt(operands.res)) {
-          throw new VirtualMachineError(ExpectedFelt);
+          throw new ExpectedFelt();
         }
         this.pc = this.pc.add(operands.res);
         break;
@@ -385,16 +385,16 @@ export class VirtualMachine {
       // If it is not, then we add the op1 to the pc.
       case 'res != 0 ? pc = op1 : pc += instruction_size':
         if (operands.dst === undefined) {
-          throw new VirtualMachineError(InvalidDstOperand);
+          throw new InvalidDstOperand();
         }
         if (Felt.isFelt(operands.dst) && operands.dst.eq(Felt.ZERO)) {
           this.incrementPc(instruction.size());
         } else {
           if (operands.op1 === undefined) {
-            throw new VirtualMachineError(InvalidOp1);
+            throw new InvalidOp1();
           }
           if (!Felt.isFelt(operands.op1)) {
-            throw new VirtualMachineError(ExpectedFelt);
+            throw new ExpectedFelt();
           }
           this.pc = this.pc.add(operands.op1);
         }
@@ -414,7 +414,7 @@ export class VirtualMachine {
       // if a relocatable.
       case 'fp = relocatable(dst) || fp += felt(dst)':
         if (operands.dst === undefined) {
-          throw new VirtualMachineError(InvalidDstOperand);
+          throw new InvalidDstOperand();
         }
         if (Felt.isFelt(operands.dst)) {
           this.fp = this.fp.add(operands.dst);
@@ -432,10 +432,10 @@ export class VirtualMachine {
       // If the ap update logic is add, then we add the result to the ap.
       case 'ap = ap + res':
         if (operands.res === undefined) {
-          throw new VirtualMachineError(UnconstrainedResError);
+          throw new UnconstrainedResError();
         }
         if (!Felt.isFelt(operands.res)) {
-          throw new VirtualMachineError(ExpectedFelt);
+          throw new ExpectedFelt();
         }
 
         this.ap = this.ap.add(operands.res);
@@ -462,10 +462,10 @@ export class VirtualMachine {
       // res represents the right side of the computation.
       case 'assert_eq':
         if (operands.res === undefined) {
-          throw new VirtualMachineError(UnconstrainedResError);
+          throw new UnconstrainedResError();
         }
         if (operands.dst !== operands.res) {
-          throw new VirtualMachineError(DiffAssertValuesError);
+          throw new DiffAssertValuesError();
         }
         break;
       // For a call, check that op0 = pc + instruction size and dst = fp.
@@ -474,10 +474,10 @@ export class VirtualMachine {
       case 'call':
         const nextPc = this.pc.add(instruction.size());
         if (operands.op0 === undefined || !nextPc.eq(operands.op0)) {
-          throw new VirtualMachineError(InvalidOp0);
+          throw new InvalidOp0();
         }
         if (this.fp !== operands.dst) {
-          throw new VirtualMachineError(InvalidDstOperand);
+          throw new InvalidDstOperand();
         }
         break;
     }


### PR DESCRIPTION
Move error handling from a few classes with specific strings to classes-only.
It allow for a more granular error management.

Currently unused errors have been deleted.

Too verbose errors were renamed:
- `InvalidOperandOneSource` -> `InvalidOp1Source`
- `InvalidOperand0` -> `InvalidOp0`
- `InvalidOperand1` -> `InvalidOp1`