### PR TITLE
feat: Add proper felt division

### DIFF
--- a/src/primitives/felt.test.ts
+++ b/src/primitives/felt.test.ts
@@ -107,19 +107,14 @@ describe('Felt', () => {
   });
 
   describe('div', () => {
-    test('should divide two felts properly', () => {
-      const a = new Felt(10n);
-      const b = new Felt(2n);
-      const result = a.div(b);
-      const expected = new Felt(5n);
-      expect(result.eq(expected)).toBeTrue();
-    });
-    test('should go to 0 if a < b in a/b', () => {
-      const a = new Felt(5n);
-      const b = new Felt(10n);
-      const result = a.div(b);
-      const expected = new Felt(0n);
-      expect(result.eq(expected)).toBeTrue();
+    test.each([
+      [new Felt(10n), new Felt(2n)],
+      [new Felt(5n), new Felt(10n)],
+      [new Felt(Felt.PRIME - 10n), new Felt(10n)],
+      [new Felt(10n), new Felt(Felt.PRIME - 10n)],
+    ])('should divide two felts properly', (a: Felt, b: Felt) => {
+      const result = a.div(b).mul(b);
+      expect(result).toStrictEqual(a);
     });
   });
 });

--- a/src/primitives/felt.ts
+++ b/src/primitives/felt.ts
@@ -42,7 +42,8 @@ export class Felt {
     if (!isFelt(other) || other.inner === 0n) {
       throw new ForbiddenOperation();
     }
-    return new Felt(this.inner / other.inner);
+
+    return this.mul(other.inv());
   }
 
   eq(other: MaybeRelocatable): boolean {
@@ -59,5 +60,29 @@ export class Felt {
 
   toHexString(): string {
     return this.inner.toString(16);
+  }
+
+  /**
+   * @dev Compute modular multiplicative inverse with
+   * Euler totient's function and Fermat's little theorem
+   */
+  private inv(): Felt {
+    return this.pow(Felt.PRIME - 2n);
+  }
+
+  /** @dev Binary Exponentiation - Iterative version */
+  private pow(exp: bigint): Felt {
+    if (exp === 0n) return new Felt(1n);
+    if (exp === 1n) return this;
+    let res = 1n;
+    let inner = this.inner;
+    while (exp !== 0n) {
+      if (exp & 1n) {
+        res = (res * inner) % Felt.PRIME;
+      }
+      inner = (inner * inner) % Felt.PRIME;
+      exp >>= 1n;
+    }
+    return new Felt(res);
   }
 }

--- a/src/vm/virtualMachine.test.ts
+++ b/src/vm/virtualMachine.test.ts
@@ -155,7 +155,7 @@ describe('VirtualMachine', () => {
     test('should deduce op1 for assert eq res logic add', () => {
       const instruction = getInstructionWithOpcodeAndOpLogic(
         'assert_eq',
-        'op0 * op1'
+        'op0 + op1'
       );
       const vm = new VirtualMachine();
       const dst = new Felt(3n);


### PR DESCRIPTION
Solves #49 

Add Felt division (modular multiplicative inverse) based on the binary exponentiation.

Identified a bug in the test case "should deduce op1 for assert eq res logic add", using the oplogic "op0 * op1" instead of "op0 + op1". It confirms that string types are not suitable to perform this logic and should rather use enum/const objects, which will be addressed in another PR.

Haven't spotted this bug before, as `div` was an integer division `3n - 2n == 1n` and `3n / 2n == 1n`, test succeeding in both cases