### PR TITLE
feat: implement trace and relocate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 
 cairo_programs/**/*.json
+*.bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 
 cairo_programs/**/*.json
-*.bin
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 
 cairo_programs/**/*.json
-tmp

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -59,11 +59,16 @@ export class Memory {
 
   toString(): string {
     const buffer = ['\nMEMORY', 'Address  ->  Value', '-----------------'];
-    for (const [index, segment] of this.values.entries()) {
-      for (const [offset, value] of segment.entries()) {
-        buffer.push(`${index}:${offset} -> ${value.toString()}`);
-      }
-    }
+    buffer.push(
+      this.values
+        .map((segment, index) =>
+          segment.map(
+            (value, offset) => `${index}:${offset} -> ${value.toString()}`
+          )
+        )
+        .flat()
+        .join('\n')
+    );
     return buffer.join('\n');
   }
 }

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -57,14 +57,17 @@ export class Memory {
     return this.values[segment]?.length ?? 0;
   }
 
-  printMemory() {
-    console.log('MEMORY');
-    console.log('Address  |  Value');
-    console.log('-----------------');
+  toString(): string {
+    const memoryToPrint = [
+      '\nMEMORY',
+      'Address  ->  Value',
+      '-----------------',
+    ];
     for (const [index, segment] of Object.entries(this.values)) {
       for (const [offset, value] of segment.entries()) {
-        console.log(`${index}:${offset} -> ${value.toString()}`);
+        memoryToPrint.push(`${index}:${offset} -> ${value.toString()}`);
       }
     }
+    return memoryToPrint.join('\n');
   }
 }

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -43,11 +43,8 @@ export class Memory {
       throw new SegmentOutOfBounds(segment, segmentNumber);
     }
 
-    const currentValue: SegmentValue | undefined = this.values[segment][offset];
-
-    if (currentValue === undefined) {
-      this.values[segment][offset] = value;
-    } else if (currentValue !== value) {
+    this.values[segment][offset] = this.values[segment][offset] ?? value;
+    if (this.values[segment][offset] !== value) {
       throw new InconsistentMemory(
         address,
         this.values[segment][offset],

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -58,16 +58,12 @@ export class Memory {
   }
 
   toString(): string {
-    const memoryToPrint = [
-      '\nMEMORY',
-      'Address  ->  Value',
-      '-----------------',
-    ];
+    const buffer = ['\nMEMORY', 'Address  ->  Value', '-----------------'];
     for (const [index, segment] of this.values.entries()) {
       for (const [offset, value] of segment.entries()) {
-        memoryToPrint.push(`${index}:${offset} -> ${value.toString()}`);
+        buffer.push(`${index}:${offset} -> ${value.toString()}`);
       }
     }
-    return memoryToPrint.join('\n');
+    return buffer.join('\n');
   }
 }

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -59,4 +59,15 @@ export class Memory {
   getSegmentSize(segment: number): number {
     return this.values[segment]?.length ?? 0;
   }
+
+  printMemory() {
+    console.log('MEMORY');
+    console.log('Address  |  Value');
+    console.log('-----------------');
+    for (const [index, segment] of Object.entries(this.values)) {
+      for (const [offset, value] of segment.entries()) {
+        console.log(`${index}:${offset} -> ${value.toString()}`);
+      }
+    }
+  }
 }

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -63,7 +63,7 @@ export class Memory {
       'Address  ->  Value',
       '-----------------',
     ];
-    for (const [index, segment] of Object.entries(this.values)) {
+    for (const [index, segment] of this.values.entries()) {
       for (const [offset, value] of segment.entries()) {
         memoryToPrint.push(`${index}:${offset} -> ${value.toString()}`);
       }

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -58,17 +58,17 @@ export class Memory {
   }
 
   toString(): string {
-    const buffer = ['\nMEMORY', 'Address  ->  Value', '-----------------'];
-    buffer.push(
-      this.values
-        .map((segment, index) =>
-          segment.map(
-            (value, offset) => `${index}:${offset} -> ${value.toString()}`
-          )
+    return [
+      '\nMEMORY',
+      'Address  ->  Value',
+      '-----------------',
+      ...this.values.map((segment, index) =>
+        segment.map(
+          (value, offset) => `${index}:${offset} -> ${value.toString()}`
         )
-        .flat()
-        .join('\n')
-    );
-    return buffer.join('\n');
+      ),
+    ]
+      .flat()
+      .join('\n');
   }
 }

--- a/src/primitives/felt.ts
+++ b/src/primitives/felt.ts
@@ -58,6 +58,16 @@ export class Felt {
     return this.inner;
   }
 
+  to64BitsWords(): bigint[] {
+    const mask = 0xffffffffffffffffn;
+    return [
+      this.inner & mask,
+      (this.inner >> 64n) & mask,
+      (this.inner >> 128n) & mask,
+      (this.inner >> 192n) & mask,
+    ];
+  }
+
   toHexString(): string {
     return this.inner.toString(16);
   }

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -30,8 +30,7 @@ describe('cairoRunner', () => {
   describe('runUntilPc', () => {
     test('should return the value of the 10th fibonacci number', () => {
       const runner = new CairoRunner(PROGRAM);
-      const finalPc = new Relocatable(0, 12);
-      runner.runUntilPc(finalPc, true, true);
+      runner.runUntilPc(runner.finalPc, true, true);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
 
@@ -40,8 +39,8 @@ describe('cairoRunner', () => {
 
     test('should export encoded trace and memory', () => {
       const runner = new CairoRunner(PROGRAM);
-      const finalPc = new Relocatable(0, 12);
-      runner.runUntilPc(finalPc, true, true);
+      // const finalPc = new Relocatable(0, 12);
+      runner.runUntilPc(runner.finalPc, true, true);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
       expect(runner.vm.memory.get(executionEnd.sub(1))).toEqual(new Felt(144n));

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -34,7 +34,7 @@ describe('cairoRunner', () => {
   describe('runUntilPc', () => {
     test('should return the value of the 10th fibonacci number', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, false, true, true);
+      runner.runUntilPc(runner.finalPc, true, 0);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
 
@@ -50,7 +50,7 @@ describe('cairoRunner', () => {
     */
     test('should export encoded trace', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, true);
+      runner.runUntilPc(runner.finalPc, true, 1);
       const trace_filename = 'fibonacci_trace_ts.bin';
       const trace_path = path.join(tmpDir, trace_filename);
       runner.exportTrace(trace_path);
@@ -63,7 +63,7 @@ describe('cairoRunner', () => {
 
     test('should export encoded memory', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, true);
+      runner.runUntilPc(runner.finalPc, true, 1);
       const memory_filename = 'fibonacci_memory_ts.bin';
       const memory_path = path.join(tmpDir, memory_filename);
       runner.exportMemory(memory_path);

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -30,7 +30,7 @@ describe('cairoRunner', () => {
   describe('runUntilPc', () => {
     test('should return the value of the 10th fibonacci number', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, true, true);
+      runner.runUntilPc(runner.finalPc, false, false);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
 

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -31,7 +31,7 @@ describe('cairoRunner', () => {
     test('should return the value of the 10th fibonacci number', () => {
       const runner = new CairoRunner(PROGRAM);
       const finalPc = new Relocatable(0, 12);
-      runner.runUntilPc(finalPc, false, true, true);
+      runner.runUntilPc(finalPc, true, true);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
 
@@ -41,7 +41,7 @@ describe('cairoRunner', () => {
     test('should export encoded trace and memory', () => {
       const runner = new CairoRunner(PROGRAM);
       const finalPc = new Relocatable(0, 12);
-      runner.runUntilPc(finalPc, false, true, true);
+      runner.runUntilPc(finalPc, true, true);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
       expect(runner.vm.memory.get(executionEnd.sub(1))).toEqual(new Felt(144n));

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -34,7 +34,7 @@ describe('cairoRunner', () => {
   describe('runUntilPc', () => {
     test('should return the value of the 10th fibonacci number', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, false, false);
+      runner.runUntilPc(runner.finalPc, false, true, true);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
 
@@ -50,7 +50,7 @@ describe('cairoRunner', () => {
     */
     test('should export encoded trace', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, true, true);
+      runner.runUntilPc(runner.finalPc, true);
       const trace_filename = 'fibonacci_trace_ts.bin';
       const trace_path = path.join(tmpDir, trace_filename);
       runner.exportTrace(trace_path);
@@ -63,7 +63,7 @@ describe('cairoRunner', () => {
 
     test('should export encoded memory', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, true, true);
+      runner.runUntilPc(runner.finalPc, true);
       const memory_filename = 'fibonacci_memory_ts.bin';
       const memory_path = path.join(tmpDir, memory_filename);
       runner.exportMemory(memory_path);

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import * as fs from 'fs';
+import * as path from 'path';
 
 import { Felt } from 'primitives/felt';
 import { Relocatable } from 'primitives/relocatable';
@@ -35,6 +36,21 @@ describe('cairoRunner', () => {
       const executionEnd = runner.executionBase.add(executionSize);
 
       expect(runner.vm.memory.get(executionEnd.sub(1))).toEqual(new Felt(144n));
+    });
+
+    test('should export encoded trace and memory', () => {
+      const runner = new CairoRunner(PROGRAM);
+      const finalPc = new Relocatable(0, 12);
+      runner.runUntilPc(finalPc, false, true, true);
+      const executionSize = runner.vm.memory.getSegmentSize(1);
+      const executionEnd = runner.executionBase.add(executionSize);
+      expect(runner.vm.memory.get(executionEnd.sub(1))).toEqual(new Felt(144n));
+
+      const dir = './cairo_programs/cairo_0';
+      const trace_filename = 'fibonacci_trace_ts.bin';
+      const memory_filename = 'fibonacci_memory_ts.bin';
+      runner.exportTrace(path.join(dir, trace_filename));
+      runner.exportMemory(path.join(dir, memory_filename));
     });
   });
 });

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from 'bun:test';
+
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 
 import { Felt } from 'primitives/felt';
 import { Relocatable } from 'primitives/relocatable';
 import { parseProgram } from 'vm/program';
 import { CairoRunner } from './cairoRunner';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cairo-vm-ts-'));
 
 const FIBONACCI_PROGRAM_STRING = fs.readFileSync(
   'cairo_programs/cairo_0/fibonacci.json',
@@ -40,14 +44,10 @@ describe('cairoRunner', () => {
     test('should export encoded trace and memory', () => {
       const runner = new CairoRunner(PROGRAM);
       runner.runUntilPc(runner.finalPc, true, true);
-      const dir = 'tmp';
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir);
-      }
       const trace_filename = 'fibonacci_trace_ts.bin';
       const memory_filename = 'fibonacci_memory_ts.bin';
-      runner.exportTrace(path.join(dir, trace_filename));
-      runner.exportMemory(path.join(dir, memory_filename));
+      runner.exportTrace(path.join(tmpDir, trace_filename));
+      runner.exportMemory(path.join(tmpDir, memory_filename));
     });
   });
 });

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -39,13 +39,11 @@ describe('cairoRunner', () => {
 
     test('should export encoded trace and memory', () => {
       const runner = new CairoRunner(PROGRAM);
-      // const finalPc = new Relocatable(0, 12);
       runner.runUntilPc(runner.finalPc, true, true);
-      const executionSize = runner.vm.memory.getSegmentSize(1);
-      const executionEnd = runner.executionBase.add(executionSize);
-      expect(runner.vm.memory.get(executionEnd.sub(1))).toEqual(new Felt(144n));
-
-      const dir = './cairo_programs/cairo_0';
+      const dir = 'tmp';
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+      }
       const trace_filename = 'fibonacci_trace_ts.bin';
       const memory_filename = 'fibonacci_memory_ts.bin';
       runner.exportTrace(path.join(dir, trace_filename));

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -41,13 +41,37 @@ describe('cairoRunner', () => {
       expect(runner.vm.memory.get(executionEnd.sub(1))).toEqual(new Felt(144n));
     });
 
-    test('should export encoded trace and memory', () => {
+    /*
+     * TODO: Add differential testing of the content
+     * See this [issue](https://github.com/kkrt-labs/cairo-vm-ts/issues/59) for more details
+
+     * NOTE: `fs.access` is only used when checking if a file exists
+     * It should be removed if reading the file, to avoid race conditions
+    */
+    test('should export encoded trace', () => {
       const runner = new CairoRunner(PROGRAM);
       runner.runUntilPc(runner.finalPc, true, true);
       const trace_filename = 'fibonacci_trace_ts.bin';
+      const trace_path = path.join(tmpDir, trace_filename);
+      runner.exportTrace(trace_path);
+      expect(() =>
+        fs.access(trace_path, (err) => {
+          if (err) throw err;
+        })
+      ).not.toThrow();
+    });
+
+    test('should export encoded memory', () => {
+      const runner = new CairoRunner(PROGRAM);
+      runner.runUntilPc(runner.finalPc, true, true);
       const memory_filename = 'fibonacci_memory_ts.bin';
-      runner.exportTrace(path.join(tmpDir, trace_filename));
-      runner.exportMemory(path.join(tmpDir, memory_filename));
+      const memory_path = path.join(tmpDir, memory_filename);
+      runner.exportMemory(memory_path);
+      expect(() =>
+        fs.access(memory_path, (err) => {
+          if (err) throw err;
+        })
+      ).not.toThrow();
     });
   });
 });

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -30,7 +30,7 @@ describe('cairoRunner', () => {
     test('should return the value of the 10th fibonacci number', () => {
       const runner = new CairoRunner(PROGRAM);
       const finalPc = new Relocatable(0, 12);
-      runner.runUntilPc(finalPc, false);
+      runner.runUntilPc(finalPc, false, true, true);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
 

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -58,12 +58,8 @@ export class CairoRunner {
       this.vm.step();
       this.vm.relocate();
     }
-    if (printMemory) {
-      console.log(this.vm.memory.toString());
-    }
-    if (printRelocatedMemory) {
-      console.log(this.vm.relocatedMemoryToString());
-    }
+    if (printMemory) console.log(this.vm.memory.toString());
+    if (printRelocatedMemory) console.log(this.vm.relocatedMemoryToString());
   }
 
   /** Export the trace little-endian encoded to a file */

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -57,13 +57,12 @@ export class CairoRunner {
     while (!this.vm.pc.eq(finalPc)) {
       this.vm.step();
       this.vm.relocate();
-
-      if (printMemory) {
-        console.log(this.vm.memory.toString());
-      }
-      if (printRelocatedMemory) {
-        console.log(this.vm.relocatedMemoryToString());
-      }
+    }
+    if (printMemory) {
+      console.log(this.vm.memory.toString());
+    }
+    if (printRelocatedMemory) {
+      console.log(this.vm.relocatedMemoryToString());
     }
   }
 

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -64,15 +64,13 @@ export class CairoRunner {
 
   /** Export the trace little-endian encoded to a file */
   exportTrace(filename: string = 'encoded_trace') {
-    const buffer = new ArrayBuffer((this.vm.relocatedTrace.length + 1) * 3 * 8);
-    const view = new DataView(buffer);
-
-    this.vm.relocatedTrace.forEach((entry, step) => {
-      const byteOffset = step * 3 * 8;
-      view.setBigUint64(byteOffset, entry.ap.toBigInt(), true);
-      view.setBigUint64(byteOffset + 8, entry.fp.toBigInt(), true);
-      view.setBigUint64(byteOffset + 2 * 8, entry.pc.toBigInt(), true);
-    });
+    const buffer = BigUint64Array.from(
+      this.vm.relocatedTrace.flatMap(({ pc, ap, fp }) => [
+        ap.toBigInt(),
+        fp.toBigInt(),
+        pc.toBigInt(),
+      ])
+    );
 
     fs.writeFile(filename, buffer, { flag: 'w+' }, (err) => {
       if (err) throw err;

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -67,10 +67,10 @@ export class CairoRunner {
     this.vm.relocate();
 
     if (printMemory) {
-      this.vm.memory.printMemory();
+      console.log(this.vm.memory.toString());
     }
     if (printRelocatedMemory) {
-      this.vm.printRelocatedMemory();
+      console.log(this.vm.relocatedMemoryToString());
     }
   }
 }

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -51,28 +51,19 @@ export class CairoRunner {
   // Run until the given PC is reached.
   runUntilPc(
     finalPc: Relocatable,
-    verbose?: boolean,
     printMemory?: boolean,
     printRelocatedMemory?: boolean
   ): void {
     while (!this.vm.pc.eq(finalPc)) {
       this.vm.step();
-      if (verbose) {
-        console.log(`AP: ${this.vm.ap.toString}`);
-        console.log(`FP: ${this.vm.fp.toString()}`);
-        console.log(`PC: ${this.vm.pc.toString()}`);
+      this.vm.relocate();
 
-        console.log(`[ap - 1]: ${this.vm.memory.get(this.vm.ap.sub(1))}`);
-        console.log(`[fp]: ${this.vm.memory.get(this.vm.fp)}`);
+      if (printMemory) {
+        console.log(this.vm.memory.toString());
       }
-    }
-    this.vm.relocate();
-
-    if (printMemory) {
-      console.log(this.vm.memory.toString());
-    }
-    if (printRelocatedMemory) {
-      console.log(this.vm.relocatedMemoryToString());
+      if (printRelocatedMemory) {
+        console.log(this.vm.relocatedMemoryToString());
+      }
     }
   }
 

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -55,7 +55,7 @@ export class CairoRunner {
     printMemory?: boolean,
     printRelocatedMemory?: boolean
   ): void {
-    while (this.vm.pc.offset < finalPc.offset) {
+    while (!this.vm.pc.eq(finalPc)) {
       this.vm.step();
       if (verbose) {
         console.log(`AP: ${this.vm.ap.toString}`);

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -51,14 +51,15 @@ export class CairoRunner {
   // Run until the given PC is reached.
   runUntilPc(
     finalPc: Relocatable,
-    relocate: boolean,
+    relocate?: boolean,
+    relocateOffset: number = 0,
     printMemory?: boolean,
     printRelocatedMemory?: boolean
   ): void {
     while (!this.vm.pc.eq(finalPc)) {
       this.vm.step();
     }
-    if (relocate) this.vm.relocate();
+    if (relocate) this.vm.relocate(relocateOffset);
     if (printMemory) console.log(this.vm.memory.toString());
     if (printRelocatedMemory) console.log(this.vm.relocatedMemoryToString());
   }

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -51,13 +51,14 @@ export class CairoRunner {
   // Run until the given PC is reached.
   runUntilPc(
     finalPc: Relocatable,
+    relocate: boolean,
     printMemory?: boolean,
     printRelocatedMemory?: boolean
   ): void {
     while (!this.vm.pc.eq(finalPc)) {
       this.vm.step();
     }
-    this.vm.relocate();
+    if (relocate) this.vm.relocate();
     if (printMemory) console.log(this.vm.memory.toString());
     if (printRelocatedMemory) console.log(this.vm.relocatedMemoryToString());
   }

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -62,30 +62,45 @@ export class CairoRunner {
     if (printRelocatedMemory) console.log(this.vm.relocatedMemoryToString());
   }
 
-  /** Export the trace little-endian encoded to a file */
+  /**
+   * Export the trace little-endian encoded to a file
+   *
+   * @dev DataView must be used to enforce little-endianness
+   */
   exportTrace(filename: string = 'encoded_trace') {
-    const buffer = BigUint64Array.from(
-      this.vm.relocatedTrace.flatMap(({ pc, ap, fp }) => [
-        ap.toBigInt(),
-        fp.toBigInt(),
-        pc.toBigInt(),
-      ])
-    );
+    const buffer = new ArrayBuffer(this.vm.relocatedTrace.length * 3 * 8);
+    const view = new DataView(buffer);
+
+    this.vm.relocatedTrace.forEach(({ pc, ap, fp }, step) => {
+      const byteOffset = step * 3 * 8;
+      view.setBigUint64(byteOffset, ap.toBigInt(), true);
+      view.setBigUint64(byteOffset + 8, fp.toBigInt(), true);
+      view.setBigUint64(byteOffset + 2 * 8, pc.toBigInt(), true);
+    });
 
     fs.writeFile(filename, buffer, { flag: 'w+' }, (err) => {
       if (err) throw err;
     });
   }
 
-  /** Export the relocated memory little-endian encoded to a file */
+  /**
+   * Export the relocated memory little-endian encoded to a file
+   *
+   * @dev DataView must be used to enforce little-endianness
+   */
   exportMemory(filename: string = 'encoded_memory') {
-    const buffer = BigUint64Array.from(
-      this.vm.relocatedMemory
-        .map(({ address, value }) => {
-          return [BigInt(address), value.to64BitsWords()];
-        })
-        .flat(2)
-    );
+    const buffer = new ArrayBuffer(this.vm.relocatedMemory.length * 5 * 8);
+    const view = new DataView(buffer);
+
+    this.vm.relocatedMemory.forEach(({ address, value }) => {
+      const byteOffset = (address - 1) * 5 * 8;
+      const valueAs64BitsWords = value.to64BitsWords();
+      view.setBigUint64(byteOffset, BigInt(address), true);
+      view.setBigUint64(byteOffset + 8, valueAs64BitsWords[0], true);
+      view.setBigUint64(byteOffset + 2 * 8, valueAs64BitsWords[1], true);
+      view.setBigUint64(byteOffset + 3 * 8, valueAs64BitsWords[2], true);
+      view.setBigUint64(byteOffset + 4 * 8, valueAs64BitsWords[3], true);
+    });
 
     fs.writeFile(filename, buffer, { flag: 'w+' }, (err) => {
       if (err) throw err;

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -79,14 +79,13 @@ export class CairoRunner {
 
   /** Export the relocated memory little-endian encoded to a file */
   exportMemory(filename: string = 'encoded_memory') {
-    const buffer = new ArrayBuffer(this.vm.relocatedMemory.size * 5 * 8);
-    const view = new DataView(buffer);
-
-    this.vm.relocatedMemory.forEach((value, address) => {
-      const byteOffset = (address - 1) * 5 * 8;
-      view.setBigUint64(byteOffset, BigInt(address), true);
-      view.setBigUint64(byteOffset + 8, value.toBigInt(), true);
-    });
+    const buffer = BigUint64Array.from(
+      this.vm.relocatedMemory
+        .map(({ address, value }) => {
+          return [BigInt(address), value.to64BitsWords()];
+        })
+        .flat(2)
+    );
 
     fs.writeFile(filename, buffer, { flag: 'w+' }, (err) => {
       if (err) throw err;

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -56,8 +56,8 @@ export class CairoRunner {
   ): void {
     while (!this.vm.pc.eq(finalPc)) {
       this.vm.step();
-      this.vm.relocate();
     }
+    this.vm.relocate();
     if (printMemory) console.log(this.vm.memory.toString());
     if (printRelocatedMemory) console.log(this.vm.relocatedMemoryToString());
   }

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -47,7 +47,12 @@ export class CairoRunner {
   }
 
   // Run until the given PC is reached.
-  runUntilPc(finalPc: Relocatable, verbose: boolean = false): void {
+  runUntilPc(
+    finalPc: Relocatable,
+    verbose?: boolean,
+    printMemory?: boolean,
+    printRelocatedMemory?: boolean
+  ): void {
     while (this.vm.pc.offset < finalPc.offset) {
       this.vm.step();
       if (verbose) {
@@ -58,6 +63,14 @@ export class CairoRunner {
         console.log(`[ap - 1]: ${this.vm.memory.get(this.vm.ap.sub(1))}`);
         console.log(`[fp]: ${this.vm.memory.get(this.vm.fp)}`);
       }
+    }
+    this.vm.relocate();
+
+    if (printMemory) {
+      this.vm.memory.printMemory();
+    }
+    if (printRelocatedMemory) {
+      this.vm.printRelocatedMemory();
     }
   }
 }

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -29,6 +29,12 @@ type TraceEntry = {
   fp: Relocatable;
 };
 
+type RelocatedTraceEntry = {
+  pc: Felt;
+  ap: Felt;
+  fp: Felt;
+};
+
 export class VirtualMachine {
   private currentStep: bigint;
   memory: Memory;
@@ -37,12 +43,14 @@ export class VirtualMachine {
   ap: Relocatable;
   fp: Relocatable;
   trace: TraceEntry[];
+  relocatedTrace: RelocatedTraceEntry[];
 
   constructor() {
     this.currentStep = 0n;
     this.memory = new Memory();
     this.relocatedMemory = new Map<number, Felt>();
     this.trace = [];
+    this.relocatedTrace = [];
 
     this.pc = new Relocatable(0, 0);
     this.ap = new Relocatable(1, 0);
@@ -388,6 +396,19 @@ export class VirtualMachine {
 
         this.relocatedMemory.set(relocatedAddr, relocatedValue);
       }
+    }
+    for (const entry of this.trace) {
+      this.relocatedTrace.push({
+        pc: new Felt(
+          BigInt(relocationTable[entry.pc.segment] + entry.pc.offset)
+        ),
+        ap: new Felt(
+          BigInt(relocationTable[entry.ap.segment] + entry.ap.offset)
+        ),
+        fp: new Felt(
+          BigInt(relocationTable[entry.fp.segment] + entry.fp.offset)
+        ),
+      });
     }
   }
 

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -391,12 +391,15 @@ export class VirtualMachine {
     }
   }
 
-  printRelocatedMemory() {
-    console.log('RELOCATED MEMORY');
-    console.log('Address  |  Value');
-    console.log('-----------------');
+  relocatedMemoryToString(): string {
+    const relocatedMemoryToPrint = [
+      '\nRELOCATED MEMORY',
+      'Address  ->  Value',
+      '-----------------',
+    ];
     for (const [index, value] of this.relocatedMemory.entries()) {
-      console.log(`${index} -> ${value.toString()}`);
+      relocatedMemoryToPrint.push(`${index} -> ${value.toString()}`);
     }
+    return relocatedMemoryToPrint.join('\n');
   }
 }

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -23,6 +23,12 @@ import {
   ResLogic,
 } from './instruction';
 
+type TraceEntry = {
+  pc: Relocatable;
+  ap: Relocatable;
+  fp: Relocatable;
+};
+
 export class VirtualMachine {
   private currentStep: bigint;
   memory: Memory;
@@ -30,11 +36,13 @@ export class VirtualMachine {
   pc: Relocatable;
   ap: Relocatable;
   fp: Relocatable;
+  trace: TraceEntry[];
 
   constructor() {
     this.currentStep = 0n;
     this.memory = new Memory();
     this.relocatedMemory = new Map<number, Felt>();
+    this.trace = [];
 
     this.pc = new Relocatable(0, 0);
     this.ap = new Relocatable(1, 0);
@@ -73,7 +81,7 @@ export class VirtualMachine {
   runInstruction(instruction: Instruction): void {
     const { op0, op1, res, dst } = this.computeStepValues(instruction);
 
-    // TODO should update the trace here
+    this.trace.push({ pc: this.pc, ap: this.ap, fp: this.fp });
 
     this.updateRegisters(instruction, op1, res, dst);
 

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -402,14 +402,15 @@ export class VirtualMachine {
   }
 
   relocatedMemoryToString(): string {
-    const buffer = [
+    return [
       '\nRELOCATED MEMORY',
       'Address  ->  Value',
       '-----------------',
-    ];
-    for (const [index, value] of this.relocatedMemory.entries()) {
-      buffer.push(`${index} -> ${value.toString()}`);
-    }
-    return buffer.join('\n');
+      ...Array.from(this.relocatedMemory).map(
+        ([address, value]) => `${address} -> ${value.toString()}`
+      ),
+    ]
+      .flat()
+      .join('\n');
   }
 }

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -392,19 +392,13 @@ export class VirtualMachine {
       )
       .forEach(({ addr, value }) => this.relocatedMemory.set(addr, value));
 
-    for (const entry of this.trace) {
-      this.relocatedTrace.push({
-        pc: new Felt(
-          BigInt(relocationTable[entry.pc.segment] + entry.pc.offset)
-        ),
-        ap: new Felt(
-          BigInt(relocationTable[entry.ap.segment] + entry.ap.offset)
-        ),
-        fp: new Felt(
-          BigInt(relocationTable[entry.fp.segment] + entry.fp.offset)
-        ),
-      });
-    }
+    this.trace
+      .map(({ pc, ap, fp }) => ({
+        pc: new Felt(BigInt(relocationTable[pc.segment] + pc.offset)),
+        ap: new Felt(BigInt(relocationTable[ap.segment] + ap.offset)),
+        fp: new Felt(BigInt(relocationTable[fp.segment] + fp.offset)),
+      }))
+      .forEach((registers) => this.relocatedTrace.push(registers));
   }
 
   relocatedMemoryToString(): string {

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -375,15 +375,22 @@ export class VirtualMachine {
     }
   }
 
-  /** Relocate memory and trace */
-  relocate() {
+  /**
+   * Relocate memory and trace
+   *
+   * @param offset Sets the relocated memory start address to offset.
+   *
+   * NOTE: The current Solidity contract CpuVerifier.sol by StarkWare
+   * expects the relocated memory to start at 1.
+   *
+   * See [issue #60](https://github.com/kkrt-labs/cairo-vm-ts/issues/60) for more details
+   */
+  relocate(offset: number = 0) {
     /*
      * Each element of the relocationTable is the start address
      * of a segment in the relocated memory.
      * This address is the sum of the length of all previous segments,
-     * plus one, as the relocated memory is 1-based.
-     * We still don't know why it is 1-based, must investigate.
-     * See [issue #60](https://github.com/kkrt-labs/cairo-vm-ts/issues/60)
+     * plus one if complying with StarkWare current verifier
      */
     const relocationTable = this.memory.values
       .map((segment) => segment.length)
@@ -391,7 +398,7 @@ export class VirtualMachine {
         (
           (sum) => (value) =>
             (sum += value) - value
-        )(1)
+        )(offset)
       );
 
     this.relocatedMemory = this.memory.values.flatMap((segment, index) =>

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -372,10 +372,10 @@ export class VirtualMachine {
       relocationTable.push(memorySize);
     }
 
-    for (const [index, segment] of Object.entries(this.memory.values)) {
+    for (const [index, segment] of this.memory.values.entries()) {
       for (const [offset, value] of segment.entries()) {
         let relocatedValue: Felt;
-        const relocatedAddr = relocationTable[Number(index)] + Number(offset);
+        const relocatedAddr = relocationTable[index] + offset;
         if (isFelt(value)) {
           relocatedValue = value;
         } else if (isRelocatable(value)) {

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -413,14 +413,14 @@ export class VirtualMachine {
   }
 
   relocatedMemoryToString(): string {
-    const relocatedMemoryToPrint = [
+    const buffer = [
       '\nRELOCATED MEMORY',
       'Address  ->  Value',
       '-----------------',
     ];
     for (const [index, value] of this.relocatedMemory.entries()) {
-      relocatedMemoryToPrint.push(`${index} -> ${value.toString()}`);
+      buffer.push(`${index} -> ${value.toString()}`);
     }
-    return relocatedMemoryToPrint.join('\n');
+    return buffer.join('\n');
   }
 }

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -47,14 +47,14 @@ export class VirtualMachine {
   ap: Relocatable;
   fp: Relocatable;
   trace: TraceEntry[];
-  relocatedTrace: RelocatedTraceEntry[];
   relocatedMemory: RelocatedMemory[];
+  relocatedTrace: RelocatedTraceEntry[];
 
   constructor() {
     this.currentStep = 0n;
     this.memory = new Memory();
-    this.relocatedMemory = [];
     this.trace = [];
+    this.relocatedMemory = [];
     this.relocatedTrace = [];
 
     this.pc = new Relocatable(0, 0);
@@ -400,6 +400,13 @@ export class VirtualMachine {
       ap: new Felt(BigInt(relocationTable[ap.segment] + ap.offset)),
       fp: new Felt(BigInt(relocationTable[fp.segment] + fp.offset)),
     }));
+
+    this.trace
+      .flatMap(Object.values)
+      .map(
+        (register: Relocatable) =>
+          new Felt(BigInt(relocationTable[register.segment] + register.offset))
+      );
   }
 
   relocatedMemoryToString(): string {

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -372,13 +372,14 @@ export class VirtualMachine {
 
   /** Relocate memory and trace */
   relocate() {
-    let relocationTable = [1];
-    let memorySize = 1;
-
-    for (const segment of this.memory.values) {
-      memorySize += segment.length;
-      relocationTable.push(memorySize);
-    }
+    const relocationTable = this.memory.values
+      .map((segment) => segment.length)
+      .map(
+        (
+          (sum) => (value) =>
+            (sum += value) - value
+        )(1)
+      );
 
     for (const [index, segment] of this.memory.values.entries()) {
       for (const [offset, value] of segment.entries()) {

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -377,6 +377,14 @@ export class VirtualMachine {
 
   /** Relocate memory and trace */
   relocate() {
+    /*
+     * Each element of the relocationTable is the start address
+     * of a segment in the relocated memory.
+     * This address is the sum of the length of all previous segments,
+     * plus one, as the relocated memory is 1-based.
+     * We still don't know why it is 1-based, must investigate.
+     * See [issue #60](https://github.com/kkrt-labs/cairo-vm-ts/issues/60)
+     */
     const relocationTable = this.memory.values
       .map((segment) => segment.length)
       .map(


### PR DESCRIPTION
Solves #43 and partially #32.

- Relocate memory. The relocated memory starts at address 1 (and not 0), a Map is then used for readability
- Trace. The trace is simply a table appending the value of each registers at every step.
The type `TraceEntry` is an object containing the three registers, similar to what would be the type `Registers` if we had an attribute `registers` in the VM (potential refactoring of the attributes `pc`, `ap` and `fp`)
- Relocate Trace (not implemented yet)
- Encode Memory (resp. Trace) and write it to a file (not implemented yet)

Having a CI job that generates the execution traces (and memory) of the Cairo VM in TS + another one (or multiple ones?) such as rust or python (prod-ready) and compare them would be great. But it still needs to be thought upon and it isn't not a priority: a separate PR should be done later.