### PR TITLE
refactor: Cairo Runner

### DIFF
--- a/src/errors/memory.ts
+++ b/src/errors/memory.ts
@@ -26,10 +26,10 @@ export class SegmentOutOfBounds extends MemoryError {
   public readonly segmentIndex: number;
   public readonly segmentNumber: number;
 
-  constructor(segment_index: number, segment_number: number) {
+  constructor(segmentIndex: number, segmentNumber: number) {
     super();
-    this.segmentIndex = segment_index;
-    this.segmentNumber = segment_number;
+    this.segmentIndex = segmentIndex;
+    this.segmentNumber = segmentNumber;
   }
 }
 

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -1,58 +1,66 @@
 import { test, expect, describe } from 'bun:test';
 
 import { SegmentOutOfBounds, InconsistentMemory } from 'errors/memory';
-
 import { Felt } from 'primitives/felt';
 import { Relocatable } from 'primitives/relocatable';
 import { Memory } from './memory';
 
+const VALUES = [
+  new Relocatable(0, 0),
+  new Relocatable(0, 1),
+  new Felt(1n),
+  new Felt(2n),
+  new Relocatable(1, 1),
+];
+
 describe('Memory', () => {
+  describe('constructor', () => {
+    test('Should initialize the number of segments to 0', () => {
+      const memory = new Memory();
+      expect(memory.getSegmentNumber()).toEqual(0);
+    });
+  });
+
+  describe('addSegment', () => {
+    test('should expand the memory size', () => {
+      const memory = new Memory();
+      memory.addSegment();
+      expect(memory.getSegmentNumber()).toEqual(1);
+    });
+  });
+
   describe('get', () => {
+    test('should throw when accessing an undefined segment', () => {
+      const memory = new Memory();
+      const address = new Relocatable(0, 0);
+      expect(() => memory.get(address)).toThrow(
+        new SegmentOutOfBounds(address.segment, memory.getSegmentNumber())
+      );
+    });
+
     test('should return undefined if address is not constrained yet', () => {
       const memory = new Memory();
+      memory.addSegment();
       const address = new Relocatable(0, 0);
       const result = memory.get(address);
       expect(result).toBeUndefined();
     });
   });
 
-  const VALUES = [
-    new Relocatable(0, 0),
-    new Relocatable(0, 1),
-    new Felt(1n),
-    new Felt(2n),
-    new Relocatable(1, 1),
-  ];
-
-  describe('addSegment', () => {
-    test('should add a new segment to the memory and return a pointer to it', () => {
-      const memory = new Memory();
-      expect(memory.getSegmentNumber()).toEqual(1);
-      memory.addSegment();
-      expect(memory.getSegmentNumber()).toEqual(2);
-    });
-    test('should expand the memory size', () => {
-      const memory = new Memory();
-      memory.addSegment();
-
-      expect(memory.getSegmentNumber()).toEqual(2);
-    });
-  });
   describe('setValues', () => {
     test('should set the values in memory', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 0);
       memory.setValues(address, VALUES);
-
       expect([...memory.values[0]]).toEqual(VALUES);
     });
+
     test('should update segmentSizes', () => {
       const memory = new Memory();
       memory.addSegment();
       const address = new Relocatable(0, 0);
       memory.setValues(address, VALUES);
-
       expect(memory.getSegmentSize(0)).toEqual(5);
     });
   });

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -129,7 +129,7 @@ describe('Memory', () => {
 
       const logSpy = spyOn(memory, 'toString');
 
-      console.log(memory.toString());
+      memory.toString();
 
       expect(logSpy.mock.results[0].value).toEqual(expectedStr);
     });

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -22,7 +22,7 @@ describe('Memory', () => {
   });
 
   describe('addSegment', () => {
-    test('should expand the memory size', () => {
+    test('should add a new segment', () => {
       const memory = new Memory();
       memory.addSegment();
       expect(memory.getSegmentNumber()).toEqual(1);

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from 'bun:test';
+import { test, expect, describe, spyOn } from 'bun:test';
 
 import { SegmentOutOfBounds, InconsistentMemory } from 'errors/memory';
 import { Felt } from 'primitives/felt';
@@ -101,6 +101,37 @@ describe('Memory', () => {
       expect(() => memory.assertEq(address, VALUES[0])).toThrow(
         new SegmentOutOfBounds(address.segment, memory.getSegmentNumber())
       );
+    });
+  });
+
+  describe('toString', () => {
+    test('Memory should be correctly printed to stdout', () => {
+      const memory = new Memory();
+      memory.addSegment();
+      memory.addSegment();
+      const addresses = [
+        new Relocatable(0, 0),
+        new Relocatable(0, 2),
+        new Relocatable(1, 0),
+      ];
+      memory.assertEq(addresses[0], VALUES[2]);
+      memory.assertEq(addresses[1], VALUES[3]);
+      memory.assertEq(addresses[2], VALUES[1]);
+
+      const expectedStr = [
+        '\nMEMORY',
+        'Address  ->  Value',
+        '-----------------',
+        '0:0 -> 1',
+        '0:2 -> 2',
+        '1:0 -> 0:1',
+      ].join('\n');
+
+      const logSpy = spyOn(memory, 'toString');
+
+      console.log(memory.toString());
+
+      expect(logSpy.mock.results[0].value).toEqual(expectedStr);
     });
   });
 });

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -7,10 +7,14 @@ export class Memory {
   values: Array<Array<SegmentValue>>;
 
   constructor() {
-    this.values = [[]];
+    this.values = [];
   }
 
   get(address: Relocatable): SegmentValue | undefined {
+    const segmentNumber = this.getSegmentNumber();
+    if (address.segment >= segmentNumber) {
+      throw new SegmentOutOfBounds(address.segment, segmentNumber);
+    }
     return this.values[address.segment][address.offset];
   }
 
@@ -37,13 +41,7 @@ export class Memory {
    */
   assertEq(address: Relocatable, value: SegmentValue): void {
     const { segment, offset } = address;
-    const segmentNumber = this.getSegmentNumber();
-
-    if (segment >= segmentNumber) {
-      throw new SegmentOutOfBounds(segment, segmentNumber);
-    }
-
-    this.values[segment][offset] = this.values[segment][offset] ?? value;
+    this.values[segment][offset] = this.get(address) ?? value;
     if (this.values[segment][offset] !== value) {
       throw new InconsistentMemory(
         address,

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -7,7 +7,7 @@ import * as os from 'os';
 import { Felt } from 'primitives/felt';
 import { Relocatable } from 'primitives/relocatable';
 import { parseProgram } from 'vm/program';
-import { CairoRunner } from './cairoRunner';
+import { CairoRunner, RunOptions } from './cairoRunner';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cairo-vm-ts-'));
 
@@ -30,10 +30,14 @@ describe('cairoRunner', () => {
     });
   });
 
-  describe('runUntilPc', () => {
+  describe('run', () => {
     test('should return the value of the 10th fibonacci number', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, true, 0);
+      const config: RunOptions = {
+        relocate: true,
+        relocateOffset: 0,
+      };
+      runner.run(config);
       const executionSize = runner.vm.memory.getSegmentSize(1);
       const executionEnd = runner.executionBase.add(executionSize);
 
@@ -49,7 +53,11 @@ describe('cairoRunner', () => {
     */
     test('should export encoded trace', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, true, 1);
+      const config: RunOptions = {
+        relocate: false,
+        relocateOffset: 1,
+      };
+      runner.run(config);
       const trace_filename = 'fibonacci_trace_ts.bin';
       const trace_path = path.join(tmpDir, trace_filename);
       runner.exportTrace(trace_path);
@@ -62,7 +70,11 @@ describe('cairoRunner', () => {
 
     test('should export encoded memory', () => {
       const runner = new CairoRunner(PROGRAM);
-      runner.runUntilPc(runner.finalPc, true, 1);
+      const config: RunOptions = {
+        relocate: false,
+        relocateOffset: 1,
+      };
+      runner.run(config);
       const memory_filename = 'fibonacci_memory_ts.bin';
       const memory_path = path.join(tmpDir, memory_filename);
       runner.exportMemory(memory_path);

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -24,10 +24,10 @@ describe('cairoRunner', () => {
       expect(runner.mainOffset).toEqual(0);
       expect(runner.programBase).toEqual(new Relocatable(0, 0));
       expect(runner.executionBase).toEqual(new Relocatable(1, 0));
-      expect(runner.initialFp).toEqual(new Relocatable(1, 2));
-      expect(runner.initialAp).toEqual(new Relocatable(1, 2));
+      expect(runner.vm.pc).toEqual(new Relocatable(0, 0));
+      expect(runner.vm.ap).toEqual(new Relocatable(1, 2));
+      expect(runner.vm.fp).toEqual(new Relocatable(1, 2));
       expect(runner.finalPc).toEqual(new Relocatable(3, 0));
-      expect(runner.initialPc).toEqual(new Relocatable(0, 0));
     });
   });
 

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -21,7 +21,6 @@ describe('cairoRunner', () => {
   describe('constructor', () => {
     test('should construct', () => {
       const runner = new CairoRunner(PROGRAM);
-      expect(runner.mainOffset).toEqual(0);
       expect(runner.programBase).toEqual(new Relocatable(0, 0));
       expect(runner.executionBase).toEqual(new Relocatable(1, 0));
       expect(runner.vm.pc).toEqual(new Relocatable(0, 0));

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -9,45 +9,29 @@ export class CairoRunner {
   vm: VirtualMachine;
   programBase: Relocatable;
   executionBase: Relocatable;
-  initialPc: Relocatable;
-  initialAp: Relocatable;
-  initialFp: Relocatable;
   finalPc: Relocatable;
   mainOffset: number;
 
   constructor(program: Program) {
     this.program = program;
     const mainIdentifier = program.identifiers.get('__main__.main');
-    const mainOffset =
-      mainIdentifier !== undefined ? mainIdentifier.pc ?? 0 : 0;
+    this.mainOffset = mainIdentifier !== undefined ? mainIdentifier.pc ?? 0 : 0;
 
     this.vm = new VirtualMachine();
     this.programBase = this.vm.memory.addSegment();
-    this.mainOffset = mainOffset;
     this.executionBase = this.vm.memory.addSegment();
 
     const returnFp = this.vm.memory.addSegment();
     this.finalPc = this.vm.memory.addSegment();
     const values = [returnFp, this.finalPc];
 
-    this.initialFp = this.executionBase.add(values.length);
-    this.initialAp = this.initialFp;
+    this.vm.pc = this.programBase.add(this.mainOffset);
+    this.vm.ap = this.executionBase.add(values.length);
+    this.vm.fp = this.vm.ap;
 
-    this.initialPc = this.programBase.add(this.mainOffset);
-
-    // Initialize the program segment.
-    // This sets the bytecode of your Cairo program, at segment 0.
     this.vm.memory.setValues(this.programBase, this.program.data);
-
-    // Initialize the execution segment.
-    // This sets the initial values in Memory, at segment 1.
     this.vm.memory.setValues(this.executionBase, values);
-
-    this.vm.ap = this.initialAp;
-    this.vm.fp = this.initialFp;
-    this.vm.pc = this.initialPc;
   }
-
   // Run until the given PC is reached.
   runUntilPc(
     finalPc: Relocatable,

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -22,7 +22,7 @@ export class CairoRunner {
       mainIdentifier !== undefined ? mainIdentifier.pc ?? 0 : 0;
 
     this.vm = new VirtualMachine();
-    this.programBase = new Relocatable(0, 0);
+    this.programBase = this.vm.memory.addSegment();
     this.mainOffset = mainOffset;
     this.executionBase = this.vm.memory.addSegment();
 

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -10,12 +10,12 @@ export class CairoRunner {
   programBase: Relocatable;
   executionBase: Relocatable;
   finalPc: Relocatable;
-  mainOffset: number;
 
   constructor(program: Program) {
     this.program = program;
     const mainIdentifier = program.identifiers.get('__main__.main');
-    this.mainOffset = mainIdentifier !== undefined ? mainIdentifier.pc ?? 0 : 0;
+    const mainOffset =
+      mainIdentifier !== undefined ? mainIdentifier.pc ?? 0 : 0;
 
     this.vm = new VirtualMachine();
     this.programBase = this.vm.memory.addSegment();
@@ -25,7 +25,7 @@ export class CairoRunner {
     this.finalPc = this.vm.memory.addSegment();
     const values = [returnFp, this.finalPc];
 
-    this.vm.pc = this.programBase.add(this.mainOffset);
+    this.vm.pc = this.programBase.add(mainOffset);
     this.vm.ap = this.executionBase.add(values.length);
     this.vm.fp = this.vm.ap;
 

--- a/src/vm/virtualMachine.test.ts
+++ b/src/vm/virtualMachine.test.ts
@@ -532,7 +532,7 @@ describe('VirtualMachine', () => {
 
       const logSpy = spyOn(vm, 'relocatedMemoryToString');
 
-      console.log(vm.relocatedMemoryToString());
+      vm.relocatedMemoryToString();
 
       expect(logSpy.mock.results[0].value).toEqual(expectedStr);
     });

--- a/src/vm/virtualMachine.test.ts
+++ b/src/vm/virtualMachine.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from 'bun:test';
+import { test, expect, describe, spyOn } from 'bun:test';
 
 import {
   ExpectedFelt,
@@ -500,6 +500,41 @@ describe('VirtualMachine', () => {
         fp: new Relocatable(1, 11),
       };
       expect({ ap: vm.ap, fp: vm.fp, pc: vm.pc }).toEqual(registers);
+    });
+  });
+
+  describe('relocatedMemoryToString', () => {
+    test('should properly print relocated memory', () => {
+      const vm = new VirtualMachine();
+      vm.memory.addSegment();
+      vm.memory.addSegment();
+
+      const addresses = [
+        new Relocatable(0, 0),
+        new Relocatable(0, 2),
+        new Relocatable(1, 0),
+      ];
+      const values = [new Felt(1n), new Felt(2n), new Relocatable(0, 2)];
+      vm.memory.assertEq(addresses[0], values[0]);
+      vm.memory.assertEq(addresses[1], values[1]);
+      vm.memory.assertEq(addresses[2], values[2]);
+
+      vm.relocate();
+
+      const expectedStr = [
+        '\nRELOCATED MEMORY',
+        'Address  ->  Value',
+        '-----------------',
+        `0 -> 1`,
+        `2 -> 2`,
+        `3 -> 2`,
+      ].join('\n');
+
+      const logSpy = spyOn(vm, 'relocatedMemoryToString');
+
+      console.log(vm.relocatedMemoryToString());
+
+      expect(logSpy.mock.results[0].value).toEqual(expectedStr);
     });
   });
 });


### PR DESCRIPTION
Refactor the Cairo Runner to simplify it:

- Remove unnecessary attributes
- Cleanup constructor
- Group configuration options into a single object, might be expanded with features to be implemented

The method `runUntilPc` is renamed to `run` because the value of `pc` to run up to is computed in the constructor (`finalPc` attribute). Having the relocation of memory and trace is  much cleaner

- Refactor memory constructor to initialize memory with no segments
- Add test for printing methods of memory & relocated memory