### PR TITLE
feat: add Output builtin

### DIFF
--- a/cairo_programs/cairo_0/bitwise_output.cairo
+++ b/cairo_programs/cairo_0/bitwise_output.cairo
@@ -1,0 +1,10 @@
+%builtins output bitwise
+from starkware.cairo.common.bitwise import bitwise_and
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.serialize import serialize_word
+
+func main{output_ptr: felt*, bitwise_ptr: BitwiseBuiltin*}() {
+    let (result) = bitwise_and(1, 2);
+    serialize_word(result);
+    return ();
+}

--- a/cairo_programs/cairo_0/bitwise_output.cairo
+++ b/cairo_programs/cairo_0/bitwise_output.cairo
@@ -1,10 +1,11 @@
 %builtins output bitwise
+
 from starkware.cairo.common.bitwise import bitwise_and
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
-from starkware.cairo.common.serialize import serialize_word
 
 func main{output_ptr: felt*, bitwise_ptr: BitwiseBuiltin*}() {
     let (result) = bitwise_and(1, 2);
-    serialize_word(result);
+    assert [output_ptr] = result;
+    let output_ptr = output_ptr + 1;
     return ();
 }

--- a/cairo_programs/cairo_0/jmp.cairo
+++ b/cairo_programs/cairo_0/jmp.cairo
@@ -1,0 +1,16 @@
+%builtins output
+
+from starkware.cairo.common.serialize import serialize_word
+
+func main{output_ptr: felt*}() {
+    jmp test;
+
+    [ap] = 1, ap++;
+    jmp rel 6;
+
+    test:
+    [ap] = 2, ap++;
+
+    serialize_word([ap - 1]);
+    return ();
+}

--- a/cairo_programs/cairo_0/jmp.cairo
+++ b/cairo_programs/cairo_0/jmp.cairo
@@ -1,7 +1,5 @@
 %builtins output
 
-from starkware.cairo.common.serialize import serialize_word
-
 func main{output_ptr: felt*}() {
     jmp test;
 
@@ -11,6 +9,7 @@ func main{output_ptr: felt*}() {
     test:
     [ap] = 2, ap++;
 
-    serialize_word([ap - 1]);
+    assert [output_ptr] = [ap - 1];
+    let output_ptr = output_ptr + 1;
     return ();
 }

--- a/src/builtins/builtin.ts
+++ b/src/builtins/builtin.ts
@@ -5,6 +5,7 @@ import { ecdsaHandler } from './ecdsa';
 import { pedersenHandler } from './pedersen';
 import { poseidonHandler } from './poseidon';
 import { keccakHandler } from './keccak';
+import { outputHandler } from './output';
 
 /** Proxy handler to abstract validation & deduction rules off the VM */
 export type BuiltinHandler = ProxyHandler<Array<SegmentValue>>;
@@ -24,6 +25,7 @@ export type BuiltinHandler = ProxyHandler<Array<SegmentValue>>;
 const BUILTIN_HANDLER: {
   [key: string]: BuiltinHandler;
 } = {
+  output: outputHandler,
   bitwise: bitwiseHandler,
   ec_op: ecOpHandler,
   ecdsa: ecdsaHandler,

--- a/src/builtins/output.test.ts
+++ b/src/builtins/output.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { Memory } from 'memory/memory';
+import { outputHandler } from './output';
+import { Relocatable } from 'primitives/relocatable';
+import { ExpectedFelt } from 'errors/virtualMachine';
+import { Felt } from 'primitives/felt';
+
+describe('Output', () => {
+  test('Should properly add Felt to output segment', () => {
+    const memory = new Memory();
+    const { segmentId } = memory.addSegment(outputHandler);
+    const address = new Relocatable(segmentId, 0);
+    const a = new Felt(1n);
+    const b = new Felt(2n);
+    const c = new Felt(3n);
+
+    memory.assertEq(address, a);
+    memory.assertEq(address.add(1), b);
+    memory.assertEq(address.add(2), c);
+
+    expect(memory.segments[segmentId][0]).toEqual(new Felt(1n));
+    expect(memory.segments[segmentId][1]).toEqual(new Felt(2n));
+    expect(memory.segments[segmentId][2]).toEqual(new Felt(3n));
+  });
+
+  test('Should throw when trying to assert non-Felt value', () => {
+    const memory = new Memory();
+    const { segmentId } = memory.addSegment(outputHandler);
+    const address = new Relocatable(segmentId, 10);
+    const value = new Relocatable(0, 0);
+    expect(() => memory.assertEq(address, value)).toThrow(new ExpectedFelt());
+  });
+});

--- a/src/builtins/output.ts
+++ b/src/builtins/output.ts
@@ -1,0 +1,16 @@
+import { isFelt } from 'primitives/segmentValue';
+import { BuiltinHandler } from './builtin';
+import { ExpectedFelt } from 'errors/virtualMachine';
+import { ExpectedOffset } from 'errors/builtins';
+
+export const outputHandler: BuiltinHandler = {
+  set(target, prop, newValue): boolean {
+    if (isNaN(Number(prop))) throw new ExpectedOffset();
+    if (!isFelt(newValue)) throw new ExpectedFelt();
+
+    const offset = Number(prop);
+    target[offset] = newValue;
+
+    return true;
+  },
+};

--- a/src/memory/memory.test.ts
+++ b/src/memory/memory.test.ts
@@ -92,7 +92,7 @@ describe('Memory', () => {
       memory.assertEq(address, VALUES[0]);
 
       expect(() => memory.assertEq(address, VALUES[1])).toThrow(
-        new InconsistentMemory(address.offset, VALUES[0], VALUES[1])
+        new InconsistentMemory(address, VALUES[0], VALUES[1])
       );
     });
 

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -44,6 +44,16 @@ const KECCAK_PROGRAM_STRING = fs.readFileSync(
   'utf8'
 );
 
+const JMP_PROGRAM_STRING = fs.readFileSync(
+  'cairo_programs/cairo_0/jmp.json',
+  'utf8'
+);
+
+const BITWISE_OUTPUT_PROGRAM_STRING = fs.readFileSync(
+  'cairo_programs/cairo_0/bitwise_output.json',
+  'utf8'
+);
+
 const FIBONACCI_PROGRAM = parseProgram(FIBONACCI_PROGRAM_STRING);
 const BITWISE_PROGRAM = parseProgram(BITWISE_PROGRAM_STRING);
 const EC_OP_PROGRAM = parseProgram(EC_OP_PROGRAM_STRING);
@@ -51,6 +61,8 @@ const PEDERSEN_PROGRAM = parseProgram(PEDERSEN_PROGRAM_STRING);
 const POSEIDON_PROGRAM = parseProgram(POSEIDON_PROGRAM_STRING);
 const KECCAK_SEED_PROGRAM = parseProgram(KECCAK_SEED_PROGRAM_STRING);
 const KECCAK_PROGRAM = parseProgram(KECCAK_PROGRAM_STRING);
+const JMP_PROGRAM = parseProgram(JMP_PROGRAM_STRING);
+const BITWISE_OUTPUT_PROGRAM = parseProgram(BITWISE_OUTPUT_PROGRAM_STRING);
 
 describe('cairoRunner', () => {
   describe('constructor', () => {
@@ -295,6 +307,32 @@ describe('cairoRunner', () => {
             value
           )
         );
+      });
+    });
+
+    describe('output', () => {
+      test('Should properly store the jmp dest value in the output segment', () => {
+        const runner = new CairoRunner(JMP_PROGRAM);
+        const config: RunOptions = {
+          relocate: true,
+          relocateOffset: 1,
+        };
+        runner.run(config);
+        const output = runner.getOutput();
+        expect(output.length).toEqual(1);
+        expect(output[0]).toEqual(new Felt(2n));
+      });
+
+      test('Should properly write the result of bitwise 1 & 2 to output segment', () => {
+        const runner = new CairoRunner(BITWISE_OUTPUT_PROGRAM);
+        const config: RunOptions = {
+          relocate: true,
+          relocateOffset: 1,
+        };
+        runner.run(config);
+        const output = runner.getOutput();
+        expect(output.length).toEqual(1);
+        expect(output[0]).toEqual(new Felt(0n));
       });
     });
   });

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -106,4 +106,10 @@ export class CairoRunner {
       if (err) throw err;
     });
   }
+
+  getOutput() {
+    const builtins = this.program.builtins;
+    const outputIdx = builtins.findIndex((name) => name === 'output');
+    return outputIdx >= 0 ? this.vm.memory.segments[outputIdx + 2] : [];
+  }
 }


### PR DESCRIPTION
Closes #65 

- The output builtin has been implemented as a segment which only accepts `Felt`
- A method `getOutput()` has been added to the `CairoRunner` class to return the Output builtin segment if the builtin is in use

To find the index of the Output segment, we rely on the fact that builtins are always initialized after the Program and Execution segments (rationale for the `outputIdx + 2`)

Layouts should enforce the builtins order, with `output` always being the first one. therefore we could simply return `runner.vm.memory.segments[2]` in `getOutput`.
However layout/builtin order is not enforced atm so programs which uses builtins in a different order, like `% builtins bitwise output`  can run on our VM (whereas the cairo VM in python throws as the builtins are not ordered as expected).
This can be updated when implementing layouts.

Python implementation of the Output builtin implements a PublicMemoryPage dictionnary which seems to be only used in the starknetOS & bootloader. There is no need to implement such structure for now imo