### PR TITLE
feat: add range check builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CAIRO_0_PATH=cairo_programs/cairo_0
-CAIRO_0_FILES:=$(wildcard $(CAIRO_0_PATH)/*.cairo)
+CAIRO_0_FILES:=$(wildcard $(CAIRO_0_PATH)/**/*.cairo)
 COMPILED_CAIRO_0_FILES:=$(CAIRO_0_FILES:%.cairo=%.json)
 
 compile: $(COMPILED_CAIRO_0_FILES)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CAIRO_0_PATH=cairo_programs/cairo_0
-CAIRO_0_FILES:=$(wildcard $(CAIRO_0_PATH)/**/*.cairo)
+CAIRO_0_FILES:=$(shell find $(CAIRO_0_PATH) -name '*.cairo')
 COMPILED_CAIRO_0_FILES:=$(CAIRO_0_FILES:%.cairo=%.json)
 
 compile: $(COMPILED_CAIRO_0_FILES)

--- a/cairo_programs/cairo_0/bad_programs/bad_range_check_builtin.cairo
+++ b/cairo_programs/cairo_0/bad_programs/bad_range_check_builtin.cairo
@@ -2,6 +2,6 @@
 
 func main{range_check_ptr: felt*}() {
     assert [range_check_ptr] = -1;
-    let range_check_ptr=range_check_ptr + 1;
+    let range_check_ptr = range_check_ptr + 1;
     return ();
 }

--- a/cairo_programs/cairo_0/bad_programs/bad_range_check_builtin.cairo
+++ b/cairo_programs/cairo_0/bad_programs/bad_range_check_builtin.cairo
@@ -1,0 +1,7 @@
+%builtins range_check
+
+func main{range_check_ptr: felt*}() {
+    assert [range_check_ptr] = -1;
+    let range_check_ptr=range_check_ptr + 1;
+    return ();
+}

--- a/cairo_programs/cairo_0/keccak_builtin.cairo
+++ b/cairo_programs/cairo_0/keccak_builtin.cairo
@@ -1,4 +1,5 @@
 %builtins keccak
+
 from starkware.cairo.common.cairo_builtins import KeccakBuiltin
 from starkware.cairo.common.keccak_state import KeccakBuiltinState
 

--- a/cairo_programs/cairo_0/keccak_builtin_seed.cairo
+++ b/cairo_programs/cairo_0/keccak_builtin_seed.cairo
@@ -1,4 +1,5 @@
 %builtins keccak
+
 from starkware.cairo.common.cairo_builtins import KeccakBuiltin
 from starkware.cairo.common.keccak_state import KeccakBuiltinState
 

--- a/cairo_programs/cairo_0/poseidon_builtin.cairo
+++ b/cairo_programs/cairo_0/poseidon_builtin.cairo
@@ -1,4 +1,5 @@
 %builtins poseidon
+
 from starkware.cairo.common.cairo_builtins import PoseidonBuiltin
 from starkware.cairo.common.poseidon_state import PoseidonBuiltinState
 

--- a/cairo_programs/cairo_0/range_check_builtin.cairo
+++ b/cairo_programs/cairo_0/range_check_builtin.cairo
@@ -2,6 +2,6 @@
 
 func main{range_check_ptr: felt*}() {
     assert [range_check_ptr] = 2 ** 128 - 1;
-    let range_check_ptr=range_check_ptr + 1;
+    let range_check_ptr = range_check_ptr + 1;
     return ();
 }

--- a/cairo_programs/cairo_0/range_check_builtin.cairo
+++ b/cairo_programs/cairo_0/range_check_builtin.cairo
@@ -1,0 +1,7 @@
+%builtins range_check
+
+func main{range_check_ptr: felt*}() {
+    assert [range_check_ptr] = 2 ** 128 - 1;
+    let range_check_ptr=range_check_ptr + 1;
+    return ();
+}

--- a/src/builtins/builtin.ts
+++ b/src/builtins/builtin.ts
@@ -6,6 +6,7 @@ import { pedersenHandler } from './pedersen';
 import { poseidonHandler } from './poseidon';
 import { keccakHandler } from './keccak';
 import { outputHandler } from './output';
+import { rangeCheckHandler } from './rangeCheck';
 
 /** Proxy handler to abstract validation & deduction rules off the VM */
 export type BuiltinHandler = ProxyHandler<Array<SegmentValue>>;
@@ -32,6 +33,7 @@ const BUILTIN_HANDLER: {
   pedersen: pedersenHandler,
   poseidon: poseidonHandler,
   keccak: keccakHandler,
+  range_check: rangeCheckHandler,
 };
 
 /** Getter of the object `BUILTIN_HANDLER` */

--- a/src/builtins/rangeCheck.test.ts
+++ b/src/builtins/rangeCheck.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Relocatable } from 'primitives/relocatable';
+import { Memory } from 'memory/memory';
+import { rangeCheckHandler } from './rangeCheck';
+import { Felt } from 'primitives/felt';
+
+describe('range check', () => {
+  test.each([new Felt(0n), new Felt((1n << 128n) - 1n)])(
+    'should properly assert values inferior to 2 ** 128 in range check segment',
+    (value) => {
+      const memory = new Memory();
+      const { segmentId } = memory.addSegment(rangeCheckHandler);
+
+      const offset = 0;
+      const address = new Relocatable(segmentId, offset);
+
+      expect(() => memory.assertEq(address, value)).not.toThrow();
+      expect(memory.segments[segmentId][offset]).toEqual(value);
+    }
+  );
+
+  test.each([new Felt(1n << 128n), new Felt(-1n)])(
+    'should throw when trying to assert values equal or superior to 2 ** 128 in range check segment',
+    (value) => {
+      const memory = new Memory();
+      const { segmentId } = memory.addSegment(rangeCheckHandler);
+
+      const offset = 0;
+      const address = new Relocatable(segmentId, offset);
+
+      expect(() => memory.assertEq(address, value)).toThrow();
+      expect(memory.segments[segmentId][offset]).toBeUndefined();
+    }
+  );
+});

--- a/src/builtins/rangeCheck.ts
+++ b/src/builtins/rangeCheck.ts
@@ -1,0 +1,18 @@
+import { ExpectedOffset, RangeCheckOutOfBounds } from 'errors/builtins';
+import { BuiltinHandler } from './builtin';
+import { isFelt } from 'primitives/segmentValue';
+import { ExpectedFelt } from 'errors/virtualMachine';
+
+export const rangeCheckHandler: BuiltinHandler = {
+  set(target, prop, newValue): boolean {
+    if (isNaN(Number(prop))) throw new ExpectedOffset();
+
+    const offset = Number(prop);
+    if (!isFelt(newValue)) throw new ExpectedFelt();
+    if (newValue.toBigInt() >> 128n !== 0n) throw new RangeCheckOutOfBounds();
+
+    target[offset] = newValue;
+
+    return true;
+  },
+};

--- a/src/errors/builtins.ts
+++ b/src/errors/builtins.ts
@@ -11,6 +11,9 @@ export class UndefinedValue extends BuiltinError {
   }
 }
 
+/** Value is above Range Check upper bound */
+export class RangeCheckOutOfBounds extends BuiltinError {}
+
 /** ECDSA signature cannot be retrived from dictionnary at `offset` */
 export class UndefinedECDSASignature extends BuiltinError {
   constructor(readonly offset: number) {

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -8,6 +8,7 @@ import { Felt } from 'primitives/felt';
 import { Relocatable } from 'primitives/relocatable';
 import { parseProgram } from 'vm/program';
 import { CairoRunner, RunOptions } from './cairoRunner';
+import { RangeCheckOutOfBounds } from 'errors/builtins';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cairo-vm-ts-'));
 
@@ -54,6 +55,16 @@ const BITWISE_OUTPUT_PROGRAM_STRING = fs.readFileSync(
   'utf8'
 );
 
+const RANGE_CHECK_PROGRAM_STRING = fs.readFileSync(
+  'cairo_programs/cairo_0/range_check_builtin.json',
+  'utf8'
+);
+
+const BAD_RANGE_CHECK_PROGRAM_STRING = fs.readFileSync(
+  'cairo_programs/cairo_0/bad_programs/bad_range_check_builtin.json',
+  'utf8'
+);
+
 const FIBONACCI_PROGRAM = parseProgram(FIBONACCI_PROGRAM_STRING);
 const BITWISE_PROGRAM = parseProgram(BITWISE_PROGRAM_STRING);
 const EC_OP_PROGRAM = parseProgram(EC_OP_PROGRAM_STRING);
@@ -63,6 +74,9 @@ const KECCAK_SEED_PROGRAM = parseProgram(KECCAK_SEED_PROGRAM_STRING);
 const KECCAK_PROGRAM = parseProgram(KECCAK_PROGRAM_STRING);
 const JMP_PROGRAM = parseProgram(JMP_PROGRAM_STRING);
 const BITWISE_OUTPUT_PROGRAM = parseProgram(BITWISE_OUTPUT_PROGRAM_STRING);
+const RANGE_CHECK_PROGRAM = parseProgram(RANGE_CHECK_PROGRAM_STRING);
+
+const BAD_RANGE_CHECK_PROGRAM = parseProgram(BAD_RANGE_CHECK_PROGRAM_STRING);
 
 describe('cairoRunner', () => {
   describe('constructor', () => {
@@ -333,6 +347,31 @@ describe('cairoRunner', () => {
         const output = runner.getOutput();
         expect(output.length).toEqual(1);
         expect(output[0]).toEqual(new Felt(0n));
+      });
+    });
+
+    describe('range_check', () => {
+      test('should properly write 2 ** 128 - 1 to the range check segment', () => {
+        const runner = new CairoRunner(RANGE_CHECK_PROGRAM);
+        const config: RunOptions = {
+          relocate: true,
+          relocateOffset: 1,
+        };
+        runner.run(config);
+        const executionSize = runner.vm.memory.getSegmentSize(1);
+        const executionEnd = runner.executionBase.add(executionSize);
+        expect(runner.vm.memory.get(executionEnd.sub(2))).toEqual(
+          new Felt((1n << 128n) - 1n)
+        );
+      });
+
+      test('should crash the VM when trying to assert -1 to the range check segment', () => {
+        const runner = new CairoRunner(BAD_RANGE_CHECK_PROGRAM);
+        const config: RunOptions = {
+          relocate: true,
+          relocateOffset: 1,
+        };
+        expect(() => runner.run(config)).toThrow(new RangeCheckOutOfBounds());
       });
     });
   });


### PR DESCRIPTION
Closes #68 

- Implements the range check builtin which only allows writing Felt that are $< 2^{128}$
- Added a program that tries to assert a felt over $2^{128}$, so it could close #31 but adding a few more "bad programs" might be a great idea.
- Updated the makefile to compile any Cairo program within the `cairo_0` directory
First used recursive `wildcard` with `/**/*.cairo` but the Github Action throwed (might have GNU make version < 4.0), so I used `shell find -name` instead
- Added line breaks between builtins & imports on a few Cairo programs

