### PR TITLE
feat: add range_check96

### DIFF
--- a/cairo_programs/cairo_0/bad_programs/bad_range_check96_builtin.cairo
+++ b/cairo_programs/cairo_0/bad_programs/bad_range_check96_builtin.cairo
@@ -1,0 +1,7 @@
+%builtins range_check96
+
+func main{range_check96_ptr: felt*}() {
+    assert [range_check96_ptr] = 2 ** 96;
+    let range_check96_ptr = range_check96_ptr + 1;
+    return ();
+}

--- a/cairo_programs/cairo_0/range_check96_builtin.cairo
+++ b/cairo_programs/cairo_0/range_check96_builtin.cairo
@@ -1,0 +1,7 @@
+%builtins range_check96
+
+func main{range_check96_ptr: felt*}() {
+    assert [range_check96_ptr] = 2 ** 96 - 1;
+    let range_check96_ptr = range_check96_ptr + 1;
+    return ();
+}

--- a/src/builtins/builtin.ts
+++ b/src/builtins/builtin.ts
@@ -6,7 +6,7 @@ import { pedersenHandler } from './pedersen';
 import { poseidonHandler } from './poseidon';
 import { keccakHandler } from './keccak';
 import { outputHandler } from './output';
-import { rangeCheck96Handler, rangeCheckHandler } from './rangeCheck';
+import { rangeCheckHandler } from './rangeCheck';
 
 /** Proxy handler to abstract validation & deduction rules off the VM */
 export type BuiltinHandler = ProxyHandler<Array<SegmentValue>>;
@@ -33,8 +33,8 @@ const BUILTIN_HANDLER: {
   pedersen: pedersenHandler,
   poseidon: poseidonHandler,
   keccak: keccakHandler,
-  range_check: rangeCheckHandler,
-  range_check96: rangeCheck96Handler,
+  range_check: rangeCheckHandler(128n),
+  range_check96: rangeCheckHandler(96n),
 };
 
 /** Getter of the object `BUILTIN_HANDLER` */

--- a/src/builtins/builtin.ts
+++ b/src/builtins/builtin.ts
@@ -6,7 +6,7 @@ import { pedersenHandler } from './pedersen';
 import { poseidonHandler } from './poseidon';
 import { keccakHandler } from './keccak';
 import { outputHandler } from './output';
-import { rangeCheckHandler } from './rangeCheck';
+import { rangeCheck96Handler, rangeCheckHandler } from './rangeCheck';
 
 /** Proxy handler to abstract validation & deduction rules off the VM */
 export type BuiltinHandler = ProxyHandler<Array<SegmentValue>>;
@@ -34,6 +34,7 @@ const BUILTIN_HANDLER: {
   poseidon: poseidonHandler,
   keccak: keccakHandler,
   range_check: rangeCheckHandler,
+  range_check96: rangeCheck96Handler,
 };
 
 /** Getter of the object `BUILTIN_HANDLER` */

--- a/src/builtins/rangeCheck.test.ts
+++ b/src/builtins/rangeCheck.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { Relocatable } from 'primitives/relocatable';
 import { Memory } from 'memory/memory';
-import { rangeCheckHandler } from './rangeCheck';
+import { rangeCheck96Handler, rangeCheckHandler } from './rangeCheck';
 import { Felt } from 'primitives/felt';
 
 describe('range check', () => {
@@ -20,11 +20,39 @@ describe('range check', () => {
     }
   );
 
+  test.each([new Felt(0n), new Felt((1n << 96n) - 1n)])(
+    'should properly assert values inferior to 2 ** 96 in range check96 segment',
+    (value) => {
+      const memory = new Memory();
+      const { segmentId } = memory.addSegment(rangeCheck96Handler);
+
+      const offset = 0;
+      const address = new Relocatable(segmentId, offset);
+
+      expect(() => memory.assertEq(address, value)).not.toThrow();
+      expect(memory.segments[segmentId][offset]).toEqual(value);
+    }
+  );
+
   test.each([new Felt(1n << 128n), new Felt(-1n)])(
     'should throw when trying to assert values equal or superior to 2 ** 128 in range check segment',
     (value) => {
       const memory = new Memory();
       const { segmentId } = memory.addSegment(rangeCheckHandler);
+
+      const offset = 0;
+      const address = new Relocatable(segmentId, offset);
+
+      expect(() => memory.assertEq(address, value)).toThrow();
+      expect(memory.segments[segmentId][offset]).toBeUndefined();
+    }
+  );
+
+  test.each([new Felt(1n << 96n), new Felt(-1n)])(
+    'should throw when trying to assert values equal or superior to 2 ** 96 in range check96 segment',
+    (value) => {
+      const memory = new Memory();
+      const { segmentId } = memory.addSegment(rangeCheck96Handler);
 
       const offset = 0;
       const address = new Relocatable(segmentId, offset);

--- a/src/builtins/rangeCheck.test.ts
+++ b/src/builtins/rangeCheck.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { Relocatable } from 'primitives/relocatable';
 import { Memory } from 'memory/memory';
-import { rangeCheck96Handler, rangeCheckHandler } from './rangeCheck';
+import { rangeCheckHandler } from './rangeCheck';
 import { Felt } from 'primitives/felt';
 
 describe('range check', () => {
@@ -10,7 +10,7 @@ describe('range check', () => {
     'should properly assert values inferior to 2 ** 128 in range check segment',
     (value) => {
       const memory = new Memory();
-      const { segmentId } = memory.addSegment(rangeCheckHandler);
+      const { segmentId } = memory.addSegment(rangeCheckHandler(128n));
 
       const offset = 0;
       const address = new Relocatable(segmentId, offset);
@@ -24,7 +24,7 @@ describe('range check', () => {
     'should properly assert values inferior to 2 ** 96 in range check96 segment',
     (value) => {
       const memory = new Memory();
-      const { segmentId } = memory.addSegment(rangeCheck96Handler);
+      const { segmentId } = memory.addSegment(rangeCheckHandler(96n));
 
       const offset = 0;
       const address = new Relocatable(segmentId, offset);
@@ -38,7 +38,7 @@ describe('range check', () => {
     'should throw when trying to assert values equal or superior to 2 ** 128 in range check segment',
     (value) => {
       const memory = new Memory();
-      const { segmentId } = memory.addSegment(rangeCheckHandler);
+      const { segmentId } = memory.addSegment(rangeCheckHandler(128n));
 
       const offset = 0;
       const address = new Relocatable(segmentId, offset);
@@ -52,7 +52,7 @@ describe('range check', () => {
     'should throw when trying to assert values equal or superior to 2 ** 96 in range check96 segment',
     (value) => {
       const memory = new Memory();
-      const { segmentId } = memory.addSegment(rangeCheck96Handler);
+      const { segmentId } = memory.addSegment(rangeCheckHandler(96n));
 
       const offset = 0;
       const address = new Relocatable(segmentId, offset);

--- a/src/builtins/rangeCheck.ts
+++ b/src/builtins/rangeCheck.ts
@@ -3,7 +3,7 @@ import { BuiltinHandler } from './builtin';
 import { isFelt } from 'primitives/segmentValue';
 import { ExpectedFelt } from 'errors/virtualMachine';
 
-const rangeCheckHandlerFactory = (boundExponent: bigint): BuiltinHandler => {
+export const rangeCheckHandler = (boundExponent: bigint): BuiltinHandler => {
   return {
     set(target, prop, newValue): boolean {
       if (isNaN(Number(prop))) throw new ExpectedOffset();
@@ -18,6 +18,3 @@ const rangeCheckHandlerFactory = (boundExponent: bigint): BuiltinHandler => {
     },
   };
 };
-
-export const rangeCheckHandler = rangeCheckHandlerFactory(128n);
-export const rangeCheck96Handler = rangeCheckHandlerFactory(96n);

--- a/src/builtins/rangeCheck.ts
+++ b/src/builtins/rangeCheck.ts
@@ -3,16 +3,21 @@ import { BuiltinHandler } from './builtin';
 import { isFelt } from 'primitives/segmentValue';
 import { ExpectedFelt } from 'errors/virtualMachine';
 
-export const rangeCheckHandler: BuiltinHandler = {
-  set(target, prop, newValue): boolean {
-    if (isNaN(Number(prop))) throw new ExpectedOffset();
+const rangeCheckHandlerFactory = (boundExponent: bigint): BuiltinHandler => {
+  return {
+    set(target, prop, newValue): boolean {
+      if (isNaN(Number(prop))) throw new ExpectedOffset();
 
-    const offset = Number(prop);
-    if (!isFelt(newValue)) throw new ExpectedFelt();
-    if (newValue.toBigInt() >> 128n !== 0n) throw new RangeCheckOutOfBounds();
+      const offset = Number(prop);
+      if (!isFelt(newValue)) throw new ExpectedFelt();
+      if (newValue.toBigInt() >> boundExponent !== 0n)
+        throw new RangeCheckOutOfBounds();
 
-    target[offset] = newValue;
-
-    return true;
-  },
+      target[offset] = newValue;
+      return true;
+    },
+  };
 };
+
+export const rangeCheckHandler = rangeCheckHandlerFactory(128n);
+export const rangeCheck96Handler = rangeCheckHandlerFactory(96n);

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -78,9 +78,7 @@ export class CairoRunner {
       view.setBigUint64(byteOffset + 2 * 8, pc.toBigInt(), true);
     });
 
-    fs.writeFile(filename, buffer, { flag: 'w+' }, (err) => {
-      if (err) throw err;
-    });
+    fs.writeFileSync(filename, view, { flag: 'w+' });
   }
 
   /**
@@ -102,9 +100,7 @@ export class CairoRunner {
       view.setBigUint64(byteOffset + 4 * 8, valueAs64BitsWords[3], true);
     });
 
-    fs.writeFile(filename, buffer, { flag: 'w+' }, (err) => {
-      if (err) throw err;
-    });
+    fs.writeFileSync(filename, view, { flag: 'w+' });
   }
 
   getOutput() {


### PR DESCRIPTION
Closes #81 

Make a factory for rangeCheckHandler based on the exponent of the upper bound (multiple of 2)

Export two handlers which represents `range_check` and `range_check96` builtins, with an upper bound of $2^{128}$ and $2^{96}$