### PR TITLE
feat: implement hint processor

### DIFF
--- a/cairo_programs/cairo_0/ecdsa_builtin.cairo
+++ b/cairo_programs/cairo_0/ecdsa_builtin.cairo
@@ -1,0 +1,14 @@
+%builtins ecdsa
+
+from starkware.cairo.common.cairo_builtins import SignatureBuiltin
+
+func main{ecdsa_ptr: SignatureBuiltin*}() {
+    let signature_r = 0x6d2e2e00dfceffd6a375db04764da249a5a1534c7584738dfe01cb3944a33ee;
+    let signature_s = 0x152d64f9943290feadc803e80b05f5aa36310ee8fe46e623f10f94e33d59f93;
+    %{ ecdsa_builtin.add_signature(ids.ecdsa_ptr.address_, (ids.signature_r, ids.signature_s)) %}
+    assert ecdsa_ptr.message = 2718;
+    assert ecdsa_ptr.pub_key = 0x3d60886c2353d93ec2862e91e23036cd9999a534481166e5a616a983070434d;
+
+    let ecdsa_ptr = ecdsa_ptr + SignatureBuiltin.SIZE;
+    return ();
+}

--- a/src/builtins/ecdsa.ts
+++ b/src/builtins/ecdsa.ts
@@ -18,7 +18,7 @@ type EcdsaProxyHandler = ProxyHandler<EcdsaSegment>;
 
 const signatureHandler: ProxyHandler<EcdsaSignatureDict> = {
   set(target, prop, newValue): boolean {
-    if (isNaN(Number(prop))) throw new ExpectedOffset();
+    if (isNaN(Number(prop))) throw new ExpectedOffset(prop);
     if (!isFelt(newValue.r)) throw new ExpectedFelt(newValue.r);
     if (!isFelt(newValue.s)) throw new ExpectedFelt(newValue.s);
     const key = Number(prop);
@@ -46,7 +46,7 @@ export const ecdsaHandler: EcdsaProxyHandler = {
       return true;
     }
 
-    if (isNaN(Number(prop))) throw new ExpectedOffset();
+    if (isNaN(Number(prop))) throw new ExpectedOffset(prop);
     if (!target.signatures) throw new UndefinedSignatureDict();
     if (!isFelt(newValue)) throw new ExpectedFelt(newValue);
 

--- a/src/builtins/ecop.ts
+++ b/src/builtins/ecop.ts
@@ -37,9 +37,10 @@ export const ecOpHandler: BuiltinHandler = {
 
     const p = ProjectivePoint.fromAffine({ x: inputs[0], y: inputs[1] });
     const q = ProjectivePoint.fromAffine({ x: inputs[2], y: inputs[3] });
+    const m = inputs[4];
 
-    const r = p.multiplyAndAddUnsafe(q, _1n, inputs[4]);
-    if (r === undefined) throw new LadderFailed();
+    const r = p.multiplyAndAddUnsafe(q, _1n, m);
+    if (r === undefined) throw new LadderFailed(p, q, m);
 
     switch (ecOpIndex - inputCellsPerEcOp) {
       case 0:

--- a/src/builtins/output.ts
+++ b/src/builtins/output.ts
@@ -5,7 +5,7 @@ import { ExpectedOffset } from 'errors/builtins';
 
 export const outputHandler: BuiltinHandler = {
   set(target, prop, newValue): boolean {
-    if (isNaN(Number(prop))) throw new ExpectedOffset();
+    if (isNaN(Number(prop))) throw new ExpectedOffset(prop);
     if (!isFelt(newValue)) throw new ExpectedFelt(newValue);
 
     const offset = Number(prop);

--- a/src/builtins/rangeCheck.ts
+++ b/src/builtins/rangeCheck.ts
@@ -6,7 +6,7 @@ import { ExpectedFelt } from 'errors/primitives';
 export const rangeCheckHandler = (boundExponent: bigint): BuiltinHandler => {
   return {
     set(target, prop, newValue): boolean {
-      if (isNaN(Number(prop))) throw new ExpectedOffset();
+      if (isNaN(Number(prop))) throw new ExpectedOffset(prop);
 
       const offset = Number(prop);
       if (!isFelt(newValue)) throw new ExpectedFelt(newValue);

--- a/src/errors/builtins.ts
+++ b/src/errors/builtins.ts
@@ -1,4 +1,5 @@
 import { SignatureType } from '@noble/curves/src/abstract/weierstrass';
+import { ProjectivePoint } from '@scure/starknet';
 import { Felt } from 'primitives/felt';
 
 /** Errors related to builtins */
@@ -49,10 +50,27 @@ public key (negative): ${pubKeyNegHex}
 }
 
 /** The signature dictionnary is undefined */
-export class UndefinedSignatureDict extends BuiltinError {}
+export class UndefinedSignatureDict extends BuiltinError {
+  constructor() {
+    super('The signature dictionnary is undefined');
+  }
+}
 
 /** An offset of type number is expected */
-export class ExpectedOffset extends BuiltinError {}
+export class ExpectedOffset extends BuiltinError {
+  constructor(prop: any) {
+    super(
+      `The key to set a value to the segment is expected to be castable to number, received ${typeof prop}: ${prop}`
+    );
+  }
+}
 
 /** Ladder formula R = P + mQ failed in EcOp builtin */
-export class LadderFailed extends BuiltinError {}
+export class LadderFailed extends BuiltinError {
+  constructor(p: ProjectivePoint, q: ProjectivePoint, m: bigint) {
+    super(`Ladder formula r = P + mQ failed in EcOp builtin
+p: ${p.toHex}
+q: ${q.toHex()}
+m: 0x${m.toString(16)}`);
+  }
+}

--- a/src/errors/cairoRunner.ts
+++ b/src/errors/cairoRunner.ts
@@ -1,3 +1,7 @@
 class CairoRunnerError extends Error {}
 
-export class EmptyRelocatedMemory extends CairoRunnerError {}
+export class EmptyRelocatedMemory extends CairoRunnerError {
+  constructor() {
+    super('The relocated memory is empty, cannot relocate');
+  }
+}

--- a/src/errors/hint.ts
+++ b/src/errors/hint.ts
@@ -5,10 +5,14 @@ export class UnknownHint extends HintError {
     super(`Unknown hint - ${code}`);
   }
 }
+
 export class UnreachableReference extends HintError {
-  constructor(index: number, refManagerLen: number) {
-    super(
-      `Cannot reach the reference ${index} as there is only ${refManagerLen} references`
-    );
+  constructor(index: number) {
+    super(`Cannot reach the reference ${index} in the reference manager`);
+  }
+}
+export class EmptyVariableName extends HintError {
+  constructor() {
+    super(`The variable name string is empty`);
   }
 }

--- a/src/errors/hint.ts
+++ b/src/errors/hint.ts
@@ -5,3 +5,10 @@ export class UnknownHint extends HintError {
     super(`Unknown hint - ${code}`);
   }
 }
+export class UnreachableReference extends HintError {
+  constructor(index: number, refManagerLen: number) {
+    super(
+      `Cannot reach the reference ${index} as there is only ${refManagerLen} references`
+    );
+  }
+}

--- a/src/errors/hint.ts
+++ b/src/errors/hint.ts
@@ -1,0 +1,7 @@
+class HintError extends Error {}
+
+export class UnknownHint extends HintError {
+  constructor(code: string) {
+    super(`Unknown hint - ${code}`);
+  }
+}

--- a/src/errors/hintReference.ts
+++ b/src/errors/hintReference.ts
@@ -1,0 +1,13 @@
+class ReferenceError extends Error {}
+
+export class InvalidReference extends ReferenceError {
+  constructor(reference: string) {
+    super(`Invalid reference ${reference}`);
+  }
+}
+
+export class InvalidOffsetExpr extends ReferenceError {
+  constructor(offsetExpr: string, reference: string) {
+    super(`Invalid offset pattern ${offsetExpr} in reference ${reference}`);
+  }
+}

--- a/src/errors/idsManager.ts
+++ b/src/errors/idsManager.ts
@@ -42,3 +42,15 @@ export class ApTrackingDataGroupDifferHintRef extends IdsManagerError {
     );
   }
 }
+
+export class EmptyAccessibleScope extends IdsManagerError {
+  constructor() {
+    super('Cannot get a constant when the accessible scope is empty');
+  }
+}
+
+export class MissingConstant extends IdsManagerError {
+  constructor(name: string) {
+    super(`Constant ${name} is missing from the accessible scopes`);
+  }
+}

--- a/src/errors/idsManager.ts
+++ b/src/errors/idsManager.ts
@@ -1,0 +1,44 @@
+import { HintReference, OffsetValue } from 'hints/hintReference';
+import { Register } from 'vm/instruction';
+
+class IdsManagerError extends Error {}
+
+export class UndefinedImmediateRef extends IdsManagerError {
+  constructor(reference: HintReference) {
+    super(`Undefined immediate reference: ${reference}`);
+  }
+}
+
+export class InvalidValueType extends IdsManagerError {
+  constructor(reference: HintReference, offset: OffsetValue) {
+    super(`Invalid value type on ${offset} for reference ${reference}`);
+  }
+}
+
+export class InvalidRegister extends IdsManagerError {
+  constructor(offset: OffsetValue, register: Register | undefined) {
+    super(`Invalid register ${register} at offset ${offset}`);
+  }
+}
+
+export class UndefinedValue extends IdsManagerError {
+  constructor(offset: OffsetValue) {
+    super(`Undefined value at offset ${offset}`);
+  }
+}
+
+export class UndefinedVariable extends IdsManagerError {
+  constructor(name: string) {
+    super(`Variable ${name} is not available as reference of the hint`);
+  }
+}
+
+export class ApTrackingDataGroupDifferHintRef extends IdsManagerError {
+  constructor(hintApTrackingData: number, refApTrackingData: number) {
+    super(
+      `The ApTracking group of the hint and the reference differ:
+  - hint: ${hintApTrackingData}
+  - reference: ${refApTrackingData}`
+    );
+  }
+}

--- a/src/errors/program.ts
+++ b/src/errors/program.ts
@@ -1,0 +1,13 @@
+class ProgramError extends Error {}
+
+export class UnknownIdentifier extends ProgramError {
+  constructor(destination: string) {
+    super(`Unknown identifier ${destination}`);
+  }
+}
+
+export class InvalidIdentifierDest extends ProgramError {
+  constructor(dest: string | undefined) {
+    super(`Destination is invalid: ${dest}`);
+  }
+}

--- a/src/errors/program.ts
+++ b/src/errors/program.ts
@@ -1,11 +1,5 @@
 class ProgramError extends Error {}
 
-export class UnknownIdentifier extends ProgramError {
-  constructor(destination: string) {
-    super(`Unknown identifier ${destination}`);
-  }
-}
-
 export class InvalidIdentifierDest extends ProgramError {
   constructor(dest: string | undefined) {
     super(`Destination is invalid: ${dest}`);

--- a/src/errors/scopeManager.ts
+++ b/src/errors/scopeManager.ts
@@ -1,0 +1,13 @@
+class ScopeManager extends Error {}
+
+export class CannotExitMainScope extends ScopeManager {
+  constructor() {
+    super('Cannot exit the main scope');
+  }
+}
+
+export class VariableNotInScope extends ScopeManager {
+  constructor(name: string) {
+    super(`Variable ${name} is not in scope`);
+  }
+}

--- a/src/hints/hint.test.ts
+++ b/src/hints/hint.test.ts
@@ -7,6 +7,7 @@ import { HintData, HintProcessor } from './hint';
 import { HintReference, ValueType } from './hintReference';
 import { Register } from 'vm/instruction';
 import { IdsManager } from './idsManager';
+import { VirtualMachine } from 'vm/virtualMachine';
 
 const AP_TRACKING_DATA_DEFAULT: ApTrackingData = {
   group: 0,
@@ -16,7 +17,6 @@ const AP_TRACKING_DATA_DEFAULT: ApTrackingData = {
 describe('Hints', () => {
   describe('compile', () => {
     test('should correctly compile the given hint', () => {
-      const hintProcessor = new HintProcessor();
       const hint: Hint = {
         code: 'ids.a = ids.b',
         flow_tracking_data: {
@@ -79,12 +79,11 @@ describe('Hints', () => {
         code: 'ids.a = ids.b',
       };
 
-      const data = hintProcessor.compile(hint, refManager);
+      const data = HintProcessor.compile(hint, refManager);
       expect(data).toEqual(expectedData);
     });
 
     test('should throw when compiling a hint with a missing reference', () => {
-      const hintProcessor = new HintProcessor();
       const hint: Hint = {
         code: 'ids.a = ids.b',
         flow_tracking_data: {
@@ -98,7 +97,7 @@ describe('Hints', () => {
       };
       const refManager: ReferenceManager = { references: [] };
 
-      expect(() => hintProcessor.compile(hint, refManager)).toThrow(
+      expect(() => HintProcessor.compile(hint, refManager)).toThrow(
         new UnreachableReference(0, 0)
       );
     });
@@ -106,15 +105,18 @@ describe('Hints', () => {
 
   describe('execute', () => {
     test('should throw UnknownHint when executing a non-existing hint', () => {
+      const vm = new VirtualMachine();
       expect(() =>
-        new HintProcessor().execute({
-          accessible_scopes: [],
-          flow_tracking_data: {
-            ap_tracking: AP_TRACKING_DATA_DEFAULT,
-            reference_ids: {},
+        new HintProcessor().execute(
+          {
+            ids: new IdsManager(
+              new Map<string, HintReference>(),
+              AP_TRACKING_DATA_DEFAULT
+            ),
+            code: 'no-code',
           },
-          code: 'no-code',
-        })
+          vm
+        )
       ).toThrow(new UnknownHint('no-code'));
     });
   });

--- a/src/hints/hint.test.ts
+++ b/src/hints/hint.test.ts
@@ -18,7 +18,7 @@ describe('Hints', () => {
           accessible_scopes: [],
           flow_tracking_data: {
             ap_tracking: AP_TRACKING_DATA_DEFAULT,
-            reference_ids: new Map<string, number>(),
+            reference_ids: {},
           },
           code: 'no-code',
         })

--- a/src/hints/hint.test.ts
+++ b/src/hints/hint.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
-import { UnknownHint } from 'errors/hint';
-import { ApTrackingData } from 'vm/program';
+import { UnknownHint, UnreachableReference } from 'errors/hint';
+import { ApTrackingData, Hint, ReferenceManager } from 'vm/program';
 
-import { HintProcessor } from './hint';
+import { HintData, HintProcessor } from './hint';
+import { HintReference, ValueType } from './hintReference';
+import { Register } from 'vm/instruction';
+import { IdsManager } from './idsManager';
 
 const AP_TRACKING_DATA_DEFAULT: ApTrackingData = {
   group: 0,
@@ -11,7 +14,97 @@ const AP_TRACKING_DATA_DEFAULT: ApTrackingData = {
 };
 
 describe('Hints', () => {
-  describe('hint code', () => {
+  describe('compile', () => {
+    test('should correctly compile the given hint', () => {
+      const hintProcessor = new HintProcessor();
+      const hint: Hint = {
+        code: 'ids.a = ids.b',
+        flow_tracking_data: {
+          ap_tracking: { group: 1, offset: 2 },
+          reference_ids: {
+            '__main.__.a': 0,
+            '__main__.b': 1,
+          },
+        },
+        accessible_scopes: [],
+      };
+      const refManager: ReferenceManager = {
+        references: [
+          {
+            pc: 0,
+            ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+            value: 'cast(ap + (-2), felt)',
+          },
+          {
+            pc: 0,
+            ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+            value: 'cast(ap + (-1), felt)',
+          },
+        ],
+      };
+      const expectedData: HintData = {
+        ids: new IdsManager(
+          new Map<string, HintReference>([
+            [
+              'a',
+              {
+                valueType: 'felt',
+                dereferenced: false,
+                apTrackingData: AP_TRACKING_DATA_DEFAULT,
+                offset1: {
+                  valueType: ValueType.Reference,
+                  dereferenced: false,
+                  register: Register.Ap,
+                  value: -2,
+                },
+              },
+            ],
+            [
+              'b',
+              {
+                valueType: 'felt',
+                dereferenced: false,
+                apTrackingData: AP_TRACKING_DATA_DEFAULT,
+                offset1: {
+                  valueType: ValueType.Reference,
+                  dereferenced: false,
+                  register: Register.Ap,
+                  value: -1,
+                },
+              },
+            ],
+          ]),
+          { group: 1, offset: 2 }
+        ),
+        code: 'ids.a = ids.b',
+      };
+
+      const data = hintProcessor.compile(hint, refManager);
+      expect(data).toEqual(expectedData);
+    });
+
+    test('should throw when compiling a hint with a missing reference', () => {
+      const hintProcessor = new HintProcessor();
+      const hint: Hint = {
+        code: 'ids.a = ids.b',
+        flow_tracking_data: {
+          ap_tracking: AP_TRACKING_DATA_DEFAULT,
+          reference_ids: {
+            '__main.__.a': 0,
+            '__main__.b': 1,
+          },
+        },
+        accessible_scopes: [],
+      };
+      const refManager: ReferenceManager = { references: [] };
+
+      expect(() => hintProcessor.compile(hint, refManager)).toThrow(
+        new UnreachableReference(0, 0)
+      );
+    });
+  });
+
+  describe('execute', () => {
     test('should throw UnknownHint when executing a non-existing hint', () => {
       expect(() =>
         new HintProcessor().execute({

--- a/src/hints/hint.test.ts
+++ b/src/hints/hint.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+
+import { UnknownHint } from 'errors/hint';
+import { ApTrackingData } from 'vm/program';
+
+import { HintProcessor } from './hint';
+
+const AP_TRACKING_DATA_DEFAULT: ApTrackingData = {
+  group: 0,
+  offset: 0,
+};
+
+describe('Hints', () => {
+  describe('hint code', () => {
+    test('should throw UnknownHint when executing a non-existing hint', () => {
+      expect(() =>
+        new HintProcessor().execute({
+          accessible_scopes: [],
+          flow_tracking_data: {
+            ap_tracking: AP_TRACKING_DATA_DEFAULT,
+            reference_ids: new Map<string, number>(),
+          },
+          code: 'no-code',
+        })
+      ).toThrow(new UnknownHint('no-code'));
+    });
+  });
+});

--- a/src/hints/hint.ts
+++ b/src/hints/hint.ts
@@ -20,7 +20,7 @@ export class HintProcessor {
     this.scopeManager = new ScopeManager();
   }
 
-  compile(hint: Hint, refManager: ReferenceManager): HintData {
+  static compile(hint: Hint, refManager: ReferenceManager): HintData {
     const references = new Map<string, HintReference>();
     Object.entries(hint.flow_tracking_data.reference_ids).map(
       ([name, index]) => {

--- a/src/hints/hint.ts
+++ b/src/hints/hint.ts
@@ -20,6 +20,12 @@ export class HintProcessor {
     this.scopeManager = new ScopeManager();
   }
 
+  /** Compile an hint from the compilation artifact
+   * to a format that can be easily executed.
+   *
+   * @param hint The hint to be compiled, from the compilation
+   * @param refManager All the program references
+   */
   static compile(hint: Hint, refManager: ReferenceManager): HintData {
     const references = new Map<string, HintReference>();
     Object.entries(hint.flow_tracking_data.reference_ids).map(
@@ -40,6 +46,18 @@ export class HintProcessor {
     };
   }
 
+  /**
+   * Execute an hint based on its code
+   * `hint.code` allows mapping the Python hint code
+   * to its associated function in TypeScript
+   *
+   * `hint.ids` and `vm` provide the context
+   * on which the hint must be executed.
+   *
+   * The virtual machine stores the constants
+   * used by the program.
+   *
+   */
   execute(hint: HintData, vm: VirtualMachine) {
     switch (hint.code) {
       case hintCode.ADD_ECDSA_SIGNATURE:

--- a/src/hints/hint.ts
+++ b/src/hints/hint.ts
@@ -1,10 +1,12 @@
 import { UnknownHint, UnreachableReference } from 'errors/hint';
 
-import { Hint, ProgramConstants, ReferenceManager } from 'vm/program';
+import { Hint, ReferenceManager } from 'vm/program';
+import { VirtualMachine } from 'vm/virtualMachine';
 import { HintReference } from './hintReference';
 import { IdsManager } from './idsManager';
 import { ScopeManager } from './scopeManager';
-import { VirtualMachine } from 'vm/virtualMachine';
+import * as hintCode from './hintCode';
+import { addECDSASignature } from './signature/ecdsa';
 
 export type HintData = {
   ids: IdsManager;
@@ -38,8 +40,11 @@ export class HintProcessor {
     };
   }
 
-  execute(hint: HintData, _constants: ProgramConstants, _vm: VirtualMachine) {
+  execute(hint: HintData, vm: VirtualMachine) {
     switch (hint.code) {
+      case hintCode.ADD_ECDSA_SIGNATURE:
+        addECDSASignature(hint.ids, vm);
+        break;
       default:
         throw new UnknownHint(hint.code);
     }

--- a/src/hints/hint.ts
+++ b/src/hints/hint.ts
@@ -1,9 +1,34 @@
-import { UnknownHint } from 'errors/hint';
+import { UnknownHint, UnreachableReference } from 'errors/hint';
 
-import { Hint } from 'vm/program';
+import { Hint, ReferenceManager } from 'vm/program';
+import { HintReference } from './hintReference';
+import { IdsManager } from './idsManager';
+
+export type HintData = {
+  ids: IdsManager;
+  code: string;
+};
 
 export class HintProcessor {
-  compile(_hint: Hint) {}
+  compile(hint: Hint, refManager: ReferenceManager): HintData {
+    const references = new Map<string, HintReference>();
+    Object.entries(hint.flow_tracking_data.reference_ids).map(
+      ([name, index]) => {
+        const refManagerLen = refManager.references.length;
+        if (index >= refManagerLen)
+          throw new UnreachableReference(index, refManagerLen);
+        const splitName = name.split('.');
+        references.set(
+          splitName[splitName.length - 1],
+          HintReference.parseReference(refManager.references[index])
+        );
+      }
+    );
+    return {
+      ids: new IdsManager(references, hint.flow_tracking_data.ap_tracking),
+      code: hint.code,
+    };
+  }
 
   execute(hint: Hint) {
     switch (hint.code) {

--- a/src/hints/hint.ts
+++ b/src/hints/hint.ts
@@ -3,6 +3,7 @@ import { UnknownHint, UnreachableReference } from 'errors/hint';
 import { Hint, ReferenceManager } from 'vm/program';
 import { HintReference } from './hintReference';
 import { IdsManager } from './idsManager';
+import { ScopeManager } from './scopeManager';
 
 export type HintData = {
   ids: IdsManager;
@@ -10,6 +11,12 @@ export type HintData = {
 };
 
 export class HintProcessor {
+  public scopeManager: ScopeManager;
+
+  constructor() {
+    this.scopeManager = new ScopeManager();
+  }
+
   compile(hint: Hint, refManager: ReferenceManager): HintData {
     const references = new Map<string, HintReference>();
     Object.entries(hint.flow_tracking_data.reference_ids).map(

--- a/src/hints/hint.ts
+++ b/src/hints/hint.ts
@@ -1,9 +1,10 @@
 import { UnknownHint, UnreachableReference } from 'errors/hint';
 
-import { Hint, ReferenceManager } from 'vm/program';
+import { Hint, ProgramConstants, ReferenceManager } from 'vm/program';
 import { HintReference } from './hintReference';
 import { IdsManager } from './idsManager';
 import { ScopeManager } from './scopeManager';
+import { VirtualMachine } from 'vm/virtualMachine';
 
 export type HintData = {
   ids: IdsManager;
@@ -37,7 +38,7 @@ export class HintProcessor {
     };
   }
 
-  execute(hint: Hint) {
+  execute(hint: HintData, _constants: ProgramConstants, _vm: VirtualMachine) {
     switch (hint.code) {
       default:
         throw new UnknownHint(hint.code);

--- a/src/hints/hint.ts
+++ b/src/hints/hint.ts
@@ -1,0 +1,14 @@
+import { UnknownHint } from 'errors/hint';
+
+import { Hint } from 'vm/program';
+
+export class HintProcessor {
+  compile(_hint: Hint) {}
+
+  execute(hint: Hint) {
+    switch (hint.code) {
+      default:
+        throw new UnknownHint(hint.code);
+    }
+  }
+}

--- a/src/hints/hintCode.ts
+++ b/src/hints/hintCode.ts
@@ -1,0 +1,2 @@
+export const ADD_ECDSA_SIGNATURE =
+  'ecdsa_builtin.add_signature(ids.ecdsa_ptr.address_, (ids.signature_r, ids.signature_s))';

--- a/src/hints/hintReference.test.ts
+++ b/src/hints/hintReference.test.ts
@@ -13,139 +13,79 @@ const AP_TRACKING_DATA_DEFAULT: ApTrackingData = {
 };
 
 describe('reference', () => {
-  test('should parse cast(42, felt)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(42, felt)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+  test.each([
+    [
+      'cast(42, felt)',
       new HintReference('felt', false, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Immediate,
         dereferenced: false,
         immediate: new Felt(42n),
-      })
-    );
-  });
-
-  test('should parse cast(-42, felt)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(-42, felt)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      }),
+    ],
+    [
+      'cast(-42, felt)',
       new HintReference('felt', false, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Immediate,
         dereferenced: false,
         immediate: new Felt(-42n),
-      })
-    );
-  });
-
-  test('should parse cast(ap, felt*)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(ap, felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      }),
+    ],
+    [
+      'cast(ap, felt*)',
       new HintReference('felt*', false, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Reference,
         dereferenced: false,
         register: Register.Ap,
         value: 0,
-      })
-    );
-  });
-
-  test('should parse cast([ap], felt)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast([ap], felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      }),
+    ],
+    [
+      'cast([ap], felt*)',
       new HintReference('felt*', false, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Reference,
         dereferenced: true,
         register: Register.Ap,
         value: 0,
-      })
-    );
-  });
-
-  test('should parse [cast(fp, felt**)]', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: '[cast(fp, felt**)]',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      }),
+    ],
+    [
+      '[cast(fp, felt**)]',
       new HintReference('felt**', true, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Reference,
         dereferenced: false,
         register: Register.Fp,
         value: 0,
-      })
-    );
-  });
-
-  test('should parse cast(ap + 1, felt*)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(ap + 1, felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      }),
+    ],
+    [
+      'cast(ap + 1, felt*)',
       new HintReference('felt*', false, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Reference,
         dereferenced: false,
         register: Register.Ap,
         value: 1,
-      })
-    );
-  });
-
-  test('should parse cast(ap + (-1), felt*)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(ap + (-1), felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      }),
+    ],
+    [
+      'cast(ap + (-1), felt*)',
       new HintReference('felt*', false, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Reference,
         dereferenced: false,
         register: Register.Ap,
         value: -1,
-      })
-    );
-  });
-
-  test('should parse cast([fp + (-1)], felt)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast([fp + (-1)], felt)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      }),
+    ],
+    [
+      'cast([fp + (-1)], felt)',
       new HintReference('felt', false, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Reference,
         dereferenced: true,
         register: Register.Fp,
         value: -1,
-      })
-    );
-  });
-
-  test('should parse cast(ap + 1 + 3, felt*)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(ap + 1 + 3, felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      }),
+    ],
+    [
+      'cast(ap + 1 + 3, felt*)',
       new HintReference(
         'felt*',
         false,
@@ -157,17 +97,10 @@ describe('reference', () => {
           value: 1,
         },
         { valueType: ValueType.Value, dereferenced: false, value: 3 }
-      )
-    );
-  });
-
-  test('should parse cast(ap - 1 + 3, felt*)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(ap - 1 + 3, felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      ),
+    ],
+    [
+      'cast(ap - 1 + 3, felt*)',
       new HintReference(
         'felt*',
         false,
@@ -179,17 +112,10 @@ describe('reference', () => {
           value: -1,
         },
         { valueType: ValueType.Value, dereferenced: false, value: 3 }
-      )
-    );
-  });
-
-  test('should parse cast(ap + (-1) + 3, felt*)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(ap + (-1) + 3, felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      ),
+    ],
+    [
+      'cast(ap + (-1) + 3, felt*)',
       new HintReference(
         'felt*',
         false,
@@ -201,17 +127,10 @@ describe('reference', () => {
           value: -1,
         },
         { valueType: ValueType.Value, dereferenced: false, value: 3 }
-      )
-    );
-  });
-
-  test('should parse cast([ap + (-1)] + 3, felt)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast([ap + (-1)] + 3, felt)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      ),
+    ],
+    [
+      'cast([ap + (-1)] + 3, felt)',
       new HintReference(
         'felt',
         false,
@@ -223,17 +142,10 @@ describe('reference', () => {
           value: -1,
         },
         { valueType: ValueType.Value, dereferenced: false, value: 3 }
-      )
-    );
-  });
-
-  test('should parse cast(ap + (-1) + [fp + 3], felt*)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(ap + (-1) + [fp + 3], felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      ),
+    ],
+    [
+      'cast(ap + (-1) + [fp + 3], felt*)',
       new HintReference(
         'felt*',
         false,
@@ -250,17 +162,10 @@ describe('reference', () => {
           register: Register.Fp,
           value: 3,
         }
-      )
-    );
-  });
-
-  test('should parse cast([ap + (-1)] + fp + 3, felt*)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast([ap + (-1)] + fp + 3, felt*)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      ),
+    ],
+    [
+      'cast([ap + (-1)] + fp + 3, felt*)',
       new HintReference(
         'felt*',
         false,
@@ -277,17 +182,10 @@ describe('reference', () => {
           register: Register.Fp,
           value: 3,
         }
-      )
-    );
-  });
-
-  test('should parse cast([ap + (-1)] + [fp + (-3)], felt)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast([ap + (-1)] + [fp + (-3)], felt)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      ),
+    ],
+    [
+      'cast([ap + (-1)] + [fp + (-3)], felt)',
       new HintReference(
         'felt',
         false,
@@ -304,23 +202,23 @@ describe('reference', () => {
           register: Register.Fp,
           value: -3,
         }
-      )
-    );
-  });
-
-  test('should parse custom type cast(ap + 1, custom.type)', () => {
-    const reference: Reference = {
-      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
-      pc: 0,
-      value: 'cast(42, custom.type)',
-    };
-    expect(HintReference.parseReference(reference)).toEqual(
+      ),
+    ],
+    [
+      'cast(42, custom.type)',
       new HintReference('custom.type', false, AP_TRACKING_DATA_DEFAULT, {
         valueType: ValueType.Immediate,
         dereferenced: false,
         immediate: new Felt(42n),
-      })
-    );
+      }),
+    ],
+  ])('should correctly parse reference', (refValue, expectedRef) => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: refValue,
+    };
+    expect(HintReference.parseReference(reference)).toEqual(expectedRef);
   });
 
   test('should throw InvalidReference when parsing cat(ap + 1, felt)', () => {

--- a/src/hints/hintReference.test.ts
+++ b/src/hints/hintReference.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, test } from 'bun:test';
+
+import { InvalidOffsetExpr, InvalidReference } from 'errors/hintReference';
+
+import { Felt } from 'primitives/felt';
+import { Register } from 'vm/instruction';
+import { ApTrackingData, Reference } from 'vm/program';
+import { HintReference, ValueType } from './hintReference';
+
+const AP_TRACKING_DATA_DEFAULT: ApTrackingData = {
+  group: 0,
+  offset: 0,
+};
+
+describe('reference', () => {
+  test('should parse cast(42, felt)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(42, felt)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('felt', false, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Immediate,
+        dereferenced: false,
+        immediate: new Felt(42n),
+      })
+    );
+  });
+
+  test('should parse cast(-42, felt)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(-42, felt)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('felt', false, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Immediate,
+        dereferenced: false,
+        immediate: new Felt(-42n),
+      })
+    );
+  });
+
+  test('should parse cast(ap, felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(ap, felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('felt*', false, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Reference,
+        dereferenced: false,
+        register: Register.Ap,
+        value: 0,
+      })
+    );
+  });
+
+  test('should parse cast([ap], felt)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast([ap], felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('felt*', false, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Reference,
+        dereferenced: true,
+        register: Register.Ap,
+        value: 0,
+      })
+    );
+  });
+
+  test('should parse [cast(fp, felt**)]', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: '[cast(fp, felt**)]',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('felt**', true, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Reference,
+        dereferenced: false,
+        register: Register.Fp,
+        value: 0,
+      })
+    );
+  });
+
+  test('should parse cast(ap + 1, felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(ap + 1, felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('felt*', false, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Reference,
+        dereferenced: false,
+        register: Register.Ap,
+        value: 1,
+      })
+    );
+  });
+
+  test('should parse cast(ap + (-1), felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(ap + (-1), felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('felt*', false, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Reference,
+        dereferenced: false,
+        register: Register.Ap,
+        value: -1,
+      })
+    );
+  });
+
+  test('should parse cast([fp + (-1)], felt)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast([fp + (-1)], felt)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('felt', false, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Reference,
+        dereferenced: true,
+        register: Register.Fp,
+        value: -1,
+      })
+    );
+  });
+
+  test('should parse cast(ap + 1 + 3, felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(ap + 1 + 3, felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference(
+        'felt*',
+        false,
+        AP_TRACKING_DATA_DEFAULT,
+        {
+          valueType: ValueType.Reference,
+          dereferenced: false,
+          register: Register.Ap,
+          value: 1,
+        },
+        { valueType: ValueType.Value, dereferenced: false, value: 3 }
+      )
+    );
+  });
+
+  test('should parse cast(ap - 1 + 3, felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(ap - 1 + 3, felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference(
+        'felt*',
+        false,
+        AP_TRACKING_DATA_DEFAULT,
+        {
+          valueType: ValueType.Reference,
+          dereferenced: false,
+          register: Register.Ap,
+          value: -1,
+        },
+        { valueType: ValueType.Value, dereferenced: false, value: 3 }
+      )
+    );
+  });
+
+  test('should parse cast(ap + (-1) + 3, felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(ap + (-1) + 3, felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference(
+        'felt*',
+        false,
+        AP_TRACKING_DATA_DEFAULT,
+        {
+          valueType: ValueType.Reference,
+          dereferenced: false,
+          register: Register.Ap,
+          value: -1,
+        },
+        { valueType: ValueType.Value, dereferenced: false, value: 3 }
+      )
+    );
+  });
+
+  test('should parse cast([ap + (-1)] + 3, felt)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast([ap + (-1)] + 3, felt)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference(
+        'felt',
+        false,
+        AP_TRACKING_DATA_DEFAULT,
+        {
+          valueType: ValueType.Reference,
+          dereferenced: true,
+          register: Register.Ap,
+          value: -1,
+        },
+        { valueType: ValueType.Value, dereferenced: false, value: 3 }
+      )
+    );
+  });
+
+  test('should parse cast(ap + (-1) + [fp + 3], felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(ap + (-1) + [fp + 3], felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference(
+        'felt*',
+        false,
+        AP_TRACKING_DATA_DEFAULT,
+        {
+          valueType: ValueType.Reference,
+          dereferenced: false,
+          register: Register.Ap,
+          value: -1,
+        },
+        {
+          valueType: ValueType.Reference,
+          dereferenced: true,
+          register: Register.Fp,
+          value: 3,
+        }
+      )
+    );
+  });
+
+  test('should parse cast([ap + (-1)] + fp + 3, felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast([ap + (-1)] + fp + 3, felt*)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference(
+        'felt*',
+        false,
+        AP_TRACKING_DATA_DEFAULT,
+        {
+          valueType: ValueType.Reference,
+          dereferenced: true,
+          register: Register.Ap,
+          value: -1,
+        },
+        {
+          valueType: ValueType.Reference,
+          dereferenced: false,
+          register: Register.Fp,
+          value: 3,
+        }
+      )
+    );
+  });
+
+  test('should parse cast([ap + (-1)] + [fp + (-3)], felt)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast([ap + (-1)] + [fp + (-3)], felt)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference(
+        'felt',
+        false,
+        AP_TRACKING_DATA_DEFAULT,
+        {
+          valueType: ValueType.Reference,
+          dereferenced: true,
+          register: Register.Ap,
+          value: -1,
+        },
+        {
+          valueType: ValueType.Reference,
+          dereferenced: true,
+          register: Register.Fp,
+          value: -3,
+        }
+      )
+    );
+  });
+
+  test('should parse custom type cast(ap + 1, custom.type)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(42, custom.type)',
+    };
+    expect(HintReference.parseReference(reference)).toEqual(
+      new HintReference('custom.type', false, AP_TRACKING_DATA_DEFAULT, {
+        valueType: ValueType.Immediate,
+        dereferenced: false,
+        immediate: new Felt(42n),
+      })
+    );
+  });
+
+  test('should throw InvalidReference when parsing cat(ap + 1, felt)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cat(ap + 1, felt)',
+    };
+    expect(() => HintReference.parseReference(reference)).toThrow(
+      new InvalidReference('cat(ap + 1, felt)')
+    );
+  });
+
+  test('should throw InvalidOffsetExpr when parsing cast(app + 1, felt)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(app + 1, felt)',
+    };
+    expect(() => HintReference.parseReference(reference)).toThrow(
+      new InvalidOffsetExpr('app + 1', 'cast(app + 1, felt)')
+    );
+  });
+
+  test('should throw InvalidOffsetExpr when parsing cast(ap + 1 + gp, felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast(ap + 1 + gp, felt*)',
+    };
+    expect(() => HintReference.parseReference(reference)).toThrow(
+      new InvalidOffsetExpr('ap + 1 + gp', 'cast(ap + 1 + gp, felt*)')
+    );
+  });
+
+  test('should throw InvalidOffsetExpr when parsing cast([ap + 1] + gp, felt*)', () => {
+    const reference: Reference = {
+      ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+      pc: 0,
+      value: 'cast([ap + 1] + gp, felt*)',
+    };
+    expect(() => HintReference.parseReference(reference)).toThrow(
+      new InvalidOffsetExpr('gp', 'cast([ap + 1] + gp, felt*)')
+    );
+  });
+});

--- a/src/hints/hintReference.ts
+++ b/src/hints/hintReference.ts
@@ -1,0 +1,203 @@
+import { ApTrackingData, Reference } from 'vm/program';
+import { Felt } from 'primitives/felt';
+import { Register } from 'vm/instruction';
+import { InvalidOffsetExpr, InvalidReference } from 'errors/hintReference';
+
+export enum ValueType {
+  Value,
+  Immediate,
+  Reference,
+}
+
+export type OffsetValue = {
+  valueType: ValueType;
+  dereferenced: boolean;
+  immediate?: Felt;
+  value?: number;
+  register?: Register;
+};
+
+export class HintReference {
+  constructor(
+    public valueType: string,
+    public dereferenced: boolean,
+    public apTrackingData: ApTrackingData,
+    public offset1: OffsetValue,
+    public offset2?: OffsetValue
+  ) {
+    this.valueType = valueType;
+    this.dereferenced = dereferenced;
+    this.apTrackingData = apTrackingData;
+    this.offset1 = offset1;
+    this.offset2 = offset2;
+  }
+
+  static parseReference(reference: Reference) {
+    const dereferenced =
+      reference.value.startsWith('[') && reference.value.endsWith(']');
+    const ref = dereferenced ? reference.value.slice(1, -1) : reference.value;
+
+    const castMatch = ref.match(/^cast\((.+), (.+)\)$/);
+    if (!castMatch) throw new InvalidReference(ref);
+    const [, offsetExpr, valueType] = castMatch;
+
+    const offsetMatch = offsetExpr.match(
+      /^(\[?[^\[\]]+\]?)(?: \+ (\[?[^\[\]]+\]?))*$/
+    );
+
+    if (!offsetMatch) throw new InvalidOffsetExpr(offsetExpr, ref);
+    const [, offsetStr1, offsetStr2] = offsetMatch;
+
+    if (!isNaN(Number(offsetStr1)) && !offsetStr2) {
+      const offset1: OffsetValue = {
+        dereferenced: false,
+        valueType: ValueType.Immediate,
+        immediate: new Felt(BigInt(offsetStr1)),
+      };
+      return new HintReference(
+        valueType,
+        dereferenced,
+        reference.ap_tracking_data,
+        offset1
+      );
+    }
+
+    const derefOffset1 = offsetStr1.startsWith('[') && offsetStr1.endsWith(']');
+    const off1Array = derefOffset1
+      ? offsetStr1
+          .slice(1, -1)
+          .split('+')
+          .map((str) => str.trim())
+      : offsetStr1.split('+').map((str) => str.trim());
+    // cast(fp - 2 + 5, felt*)
+    if (off1Array[0] !== 'fp' && off1Array[0] !== 'ap') {
+      const off1SubExpr = off1Array[0].split('-').map((str) => str.trim());
+      if (
+        off1SubExpr.length !== 2 ||
+        (off1SubExpr[0] !== 'fp' && off1SubExpr[0] !== 'ap')
+      )
+        throw new InvalidOffsetExpr(offsetStr1, ref);
+      const value =
+        off1SubExpr[1].startsWith('(') && off1SubExpr[1].endsWith(')')
+          ? off1SubExpr[1].slice(1, -1)
+          : off1SubExpr[1];
+      if (isNaN(Number(value))) throw new InvalidOffsetExpr(offsetStr1, ref);
+      const offset1: OffsetValue = {
+        valueType: ValueType.Reference,
+        dereferenced: derefOffset1,
+        register: off1SubExpr[0] === 'fp' ? Register.Fp : Register.Ap,
+        value: -Number(value),
+      };
+      const offset2: OffsetValue = {
+        valueType: ValueType.Value,
+        dereferenced: false,
+        value: Number(off1Array[1]),
+      };
+      return new HintReference(
+        valueType,
+        dereferenced,
+        reference.ap_tracking_data,
+        offset1,
+        offset2
+      );
+    }
+    // cast(fp + (-2), felt*)
+    let off1: number = 0;
+    if (off1Array[1]) {
+      const value =
+        off1Array[1].startsWith('(') && off1Array[1].endsWith(')')
+          ? off1Array[1].slice(1, -1)
+          : off1Array[1];
+      if (isNaN(Number(value))) throw new InvalidOffsetExpr(offsetStr1, ref);
+      off1 = Number(value);
+    }
+
+    const offset1: OffsetValue = {
+      valueType: ValueType.Reference,
+      dereferenced: derefOffset1,
+      register: off1Array[0] === 'fp' ? Register.Fp : Register.Ap,
+      value: off1,
+    };
+
+    if (!offsetStr2) {
+      if (off1Array[2]) {
+        const value =
+          off1Array[2].startsWith('(') && off1Array[2].endsWith(')')
+            ? off1Array[2].slice(1, -1)
+            : off1Array[2];
+        if (isNaN(Number(value))) throw new InvalidOffsetExpr(offsetStr1, ref);
+
+        const offset2 = {
+          valueType: ValueType.Value,
+          dereferenced: false,
+          value: Number(value),
+        };
+
+        return new HintReference(
+          valueType,
+          dereferenced,
+          reference.ap_tracking_data,
+          offset1,
+          offset2
+        );
+      }
+      return new HintReference(
+        valueType,
+        dereferenced,
+        reference.ap_tracking_data,
+        offset1
+      );
+    }
+
+    const derefOffset2 = offsetStr2.startsWith('[') && offsetStr2.endsWith(']');
+    const off2Array = derefOffset2
+      ? offsetStr2
+          .slice(1, -1)
+          .split('+')
+          .map((str) => str.trim())
+      : offsetStr2.split('+').map((str) => str.trim());
+
+    if (off2Array[0] !== 'fp' && off2Array[0] !== 'ap') {
+      const value =
+        off2Array[0].startsWith('(') && off2Array[0].endsWith(')')
+          ? off2Array[0].slice(1, -1)
+          : off2Array[0];
+      if (isNaN(Number(value))) throw new InvalidOffsetExpr(offsetStr2, ref);
+      const offset2: OffsetValue = {
+        dereferenced: false,
+        valueType: ValueType.Value,
+        value: Number(value),
+      };
+      return new HintReference(
+        valueType,
+        dereferenced,
+        reference.ap_tracking_data,
+        offset1,
+        offset2
+      );
+    }
+    let off2: number = 0;
+    if (off2Array[1]) {
+      const value =
+        off2Array[1].startsWith('(') && off2Array[1].endsWith(')')
+          ? off2Array[1].slice(1, -1)
+          : off2Array[1];
+      if (isNaN(Number(value))) throw new InvalidOffsetExpr(offsetStr1, ref);
+      off2 = Number(value);
+    }
+
+    const offset2: OffsetValue = {
+      valueType: ValueType.Reference,
+      dereferenced: derefOffset2,
+      register: off2Array[0] === 'fp' ? Register.Fp : Register.Ap,
+      value: off2,
+    };
+    return new HintReference(
+      valueType,
+      dereferenced,
+      reference.ap_tracking_data,
+      offset1,
+      offset2
+    );
+  }
+}

--- a/src/hints/hintReference.ts
+++ b/src/hints/hintReference.ts
@@ -4,12 +4,30 @@ import { Felt } from 'primitives/felt';
 import { Register } from 'vm/instruction';
 import { ApTrackingData, Reference } from 'vm/program';
 
+/**
+ * - `Immediate`: Should be read as a Felt (e.g. `42`)
+ * - `Reference`: Should be read as a Relocatable,
+ * can have an associated offset (e.g. `ap + 1`, `fp`)
+ * - `Value`: Should be read as an offset value
+ * to add or subtract from a Reference (e.g. `3`)
+ */
 export enum ValueType {
-  Value,
   Immediate,
   Reference,
+  Value,
 }
 
+/**
+ * OffsetValue is an object to conveniently represent
+ * the parsed offset of a reference
+ *
+ * Depending on the valueType, `immediate`,
+ * `reference` and/or`value` are assigned a value
+ *
+ * A `ValueType.Reference` value can be `dereferenced`,
+ * meaning that the value that will be used is the
+ * memory cell read at the computed address rather than the computed address.
+ */
 export type OffsetValue = {
   valueType: ValueType;
   dereferenced: boolean;
@@ -18,6 +36,31 @@ export type OffsetValue = {
   register?: Register;
 };
 
+/**
+ * Parse a `reference` from the compilation artifact
+ * and output it in an exploitable format
+ *
+ * A reference follows the general pattern
+ * `cast(Offset1 + Offset2, valueType)`
+ * or `[cast(Offset1 + Offset2, valueType)]` if dereferenced
+ *
+ * - `valueType`: the reference value type (e.g. `felt*` in `cast(ap + 1, felt*)`)
+ * - `dereferenced`: flag whether the return value is
+ * the memory read at the computed address or the computed address
+ *
+ * Example with `ap + 1 = Relocatable(0, 2)` and `[ap + 1] = 10`
+ * - `cast(ap + 1, felt*)` returns `Relocatable(0, 2)`
+ * - `[cast(ap + 1, felt)]` returns `Felt(10n)`
+ *
+ * - `apTrackingData`: The correction to apply if one
+ * of the OffsetValue is a reference to AP.
+ * It is needed because AP changes at almost each instruction,
+ * thus the value of AP between the variable assignment
+ * and the hint execution may vary.
+ *
+ * - `offset1` The first OffsetValue.
+ * - `offset2` The second OffsetValue. It cannot be an Immediate
+ */
 export class HintReference {
   constructor(
     public valueType: string,
@@ -33,7 +76,26 @@ export class HintReference {
     this.offset2 = offset2;
   }
 
-  static parseReference(reference: Reference) {
+  /**
+   * Parse a reference string from the compilation artifact to an object
+   *
+   * @param reference The reference from the compilation artifact to be parsed
+   * @returns {HintReference} A HintReference object later used in the IdsManager to execute hints
+   *
+   * NOTE: Reference pattern
+   * - `cast(offset1 + offset2)`
+   * - `[cast(offset1 + offset2)]`
+   *
+   * with `offset1`: `immediate`, `reg1 + value1` or `[reg1 + value1]`
+   *
+   * with `offset2`: `undefined`, `reg2 + value2`, `[reg2 + value2]` or `value2`
+   *
+   * `offset2` is always undefined is `offset1` is `immediate` (e.g. `cast(42, felt)`)
+   *
+   * `value1` and `value2` are relative integers. If negative,
+   * they are wrapped into parenthesis (e.g. `cast(ap + (-1), felt*)`)
+   */
+  static parseReference(reference: Reference): HintReference {
     const dereferenced =
       reference.value.startsWith('[') && reference.value.endsWith(']');
     const ref = dereferenced ? reference.value.slice(1, -1) : reference.value;
@@ -70,7 +132,7 @@ export class HintReference {
           .split('+')
           .map((str) => str.trim())
       : offsetStr1.split('+').map((str) => str.trim());
-    // cast(fp - 2 + 5, felt*)
+    // Handle special case `cast(reg - value1 + value2)`
     if (off1Array[0] !== 'fp' && off1Array[0] !== 'ap') {
       const off1SubExpr = off1Array[0].split('-').map((str) => str.trim());
       if (
@@ -102,7 +164,7 @@ export class HintReference {
         offset2
       );
     }
-    // cast(fp + (-2), felt*)
+
     let off1: number = 0;
     if (off1Array[1]) {
       const value =

--- a/src/hints/hintReference.ts
+++ b/src/hints/hintReference.ts
@@ -1,7 +1,8 @@
-import { ApTrackingData, Reference } from 'vm/program';
+import { InvalidOffsetExpr, InvalidReference } from 'errors/hintReference';
+
 import { Felt } from 'primitives/felt';
 import { Register } from 'vm/instruction';
-import { InvalidOffsetExpr, InvalidReference } from 'errors/hintReference';
+import { ApTrackingData, Reference } from 'vm/program';
 
 export enum ValueType {
   Value,

--- a/src/hints/idsManager.test.ts
+++ b/src/hints/idsManager.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import { IdsManager } from './idsManager';
+import { HintReference } from './hintReference';
+import { ApTrackingData } from 'vm/program';
+import { VirtualMachine } from 'vm/virtualMachine';
+import { Felt } from 'primitives/felt';
+import { Relocatable } from 'primitives/relocatable';
+import { UndefinedVariable } from 'errors/idsManager';
+
+const AP_TRACKING_DATA_DEFAULT: ApTrackingData = { group: 0, offset: 0 };
+
+describe('IdsManager', () => {
+  describe('get', () => {
+    test('get simple reference value with no dereference', () => {
+      const ids = new IdsManager(
+        new Map<string, HintReference>([
+          [
+            'value',
+            HintReference.parseReference({
+              pc: 0,
+              ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+              value: 'cast(fp, felt)',
+            }),
+          ],
+        ]),
+        AP_TRACKING_DATA_DEFAULT
+      );
+      const vm = new VirtualMachine();
+      expect(ids.get('value', vm)).toEqual(vm.fp);
+    });
+
+    test('get simple reference value dereferenced', () => {
+      const ids = new IdsManager(
+        new Map<string, HintReference>([
+          [
+            'value',
+            HintReference.parseReference({
+              pc: 0,
+              ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+              value: '[cast(fp, felt)]',
+            }),
+          ],
+        ]),
+        AP_TRACKING_DATA_DEFAULT
+      );
+      const vm = new VirtualMachine();
+      vm.memory.addSegment();
+      vm.memory.addSegment();
+      const value = new Felt(3n);
+      vm.memory.assertEq(vm.fp, value);
+      expect(ids.get('value', vm)).toEqual(value);
+    });
+
+    test.each([
+      ['cast(42, felt)', new Felt(42n)],
+      ['cast(-42, felt)', new Felt(-42n)],
+    ])('get immediate', (value: string, expectedValue: Felt) => {
+      const ids = new IdsManager(
+        new Map<string, HintReference>([
+          [
+            'value',
+            HintReference.parseReference({
+              pc: 0,
+              ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+              value: value,
+            }),
+          ],
+        ]),
+        AP_TRACKING_DATA_DEFAULT
+      );
+      const vm = new VirtualMachine();
+      expect(ids.get('value', vm)).toEqual(expectedValue);
+    });
+
+    test('get reference value with ap tracking correction', () => {
+      const ids = new IdsManager(
+        new Map<string, HintReference>([
+          [
+            'value',
+            HintReference.parseReference({
+              pc: 0,
+              ap_tracking_data: { group: 1, offset: 2 },
+              value: 'cast(ap, felt)',
+            }),
+          ],
+        ]),
+        { group: 1, offset: 5 }
+      );
+      const vm = new VirtualMachine();
+      vm.ap = new Relocatable(1, 5);
+      expect(ids.get('value', vm)).toEqual(new Relocatable(1, 2));
+    });
+
+    test('get reference from complex expression with two dereference', () => {
+      const ids = new IdsManager(
+        new Map<string, HintReference>([
+          [
+            'value',
+            HintReference.parseReference({
+              pc: 0,
+              ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+              value: 'cast([ap + 1] + [fp + (-2)], felt)',
+            }),
+          ],
+        ]),
+        AP_TRACKING_DATA_DEFAULT
+      );
+      const vm = new VirtualMachine();
+      vm.memory.addSegment();
+      vm.memory.addSegment();
+      vm.fp = new Relocatable(1, 5);
+      vm.memory.assertEq(vm.ap.add(1), new Relocatable(0, 1));
+      vm.memory.assertEq(vm.fp.sub(2), new Felt(2n));
+      expect(ids.get('value', vm)).toEqual(new Relocatable(0, 3));
+    });
+
+    test('get reference from complex expression with one dereference', () => {
+      const ids = new IdsManager(
+        new Map<string, HintReference>([
+          [
+            'value',
+            HintReference.parseReference({
+              pc: 0,
+              ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+              value: 'cast([fp + 1] + (-2), felt)',
+            }),
+          ],
+        ]),
+        AP_TRACKING_DATA_DEFAULT
+      );
+      const vm = new VirtualMachine();
+      vm.memory.addSegment();
+      vm.memory.addSegment();
+      vm.memory.assertEq(vm.fp.add(1), new Relocatable(0, 4));
+      expect(ids.get('value', vm)).toEqual(new Relocatable(0, 2));
+    });
+
+    test('should throw when trying to get an unknown variable', () => {
+      const ids = new IdsManager(
+        new Map<string, HintReference>([
+          [
+            'value',
+            HintReference.parseReference({
+              pc: 0,
+              ap_tracking_data: AP_TRACKING_DATA_DEFAULT,
+              value: 'cast(fp, felt)',
+            }),
+          ],
+        ]),
+        AP_TRACKING_DATA_DEFAULT
+      );
+      const vm = new VirtualMachine();
+      vm.ap = new Relocatable(1, 5);
+      expect(() => ids.get('val', vm)).toThrow(new UndefinedVariable('val'));
+    });
+  });
+});

--- a/src/hints/idsManager.test.ts
+++ b/src/hints/idsManager.test.ts
@@ -157,4 +157,23 @@ describe('IdsManager', () => {
       expect(() => ids.get('val', vm)).toThrow(new UndefinedVariable('val'));
     });
   });
+
+  describe('getConst', () => {
+    test('should retrieve the const UPPER_BOUND', () => {
+      const ids = new IdsManager(
+        new Map<string, HintReference>(),
+        AP_TRACKING_DATA_DEFAULT,
+        [
+          'starkware.cairo.common.math',
+          'starkware.cairo.common.math.assert_250_bit',
+        ]
+      );
+      const upperBound = new Felt(250n);
+      const constants = new Map<string, Felt>([
+        ['starkware.cairo.common.math.assert_250_bit.UPPER_BOUND', upperBound],
+      ]);
+
+      expect(ids.getConst('UPPER_BOUND', constants)).toEqual(upperBound);
+    });
+  });
 });

--- a/src/hints/idsManager.test.ts
+++ b/src/hints/idsManager.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'bun:test';
-import { IdsManager } from './idsManager';
-import { HintReference } from './hintReference';
-import { ApTrackingData } from 'vm/program';
-import { VirtualMachine } from 'vm/virtualMachine';
+
+import { UndefinedVariable } from 'errors/idsManager';
+
 import { Felt } from 'primitives/felt';
 import { Relocatable } from 'primitives/relocatable';
-import { UndefinedVariable } from 'errors/idsManager';
+import { VirtualMachine } from 'vm/virtualMachine';
+import { ApTrackingData } from 'vm/program';
+
+import { HintReference } from './hintReference';
+import { IdsManager } from './idsManager';
 
 const AP_TRACKING_DATA_DEFAULT: ApTrackingData = { group: 0, offset: 0 };
 

--- a/src/hints/idsManager.ts
+++ b/src/hints/idsManager.ts
@@ -5,6 +5,8 @@ import {
   ApTrackingDataGroupDifferHintRef,
   InvalidRegister,
   UndefinedValue,
+  EmptyAccessibleScope,
+  MissingConstant,
 } from 'errors/idsManager';
 import { ExpectedRelocatable } from 'errors/primitives';
 
@@ -19,7 +21,8 @@ import { HintReference, ValueType, OffsetValue } from './hintReference';
 export class IdsManager {
   constructor(
     public references: Map<string, HintReference>,
-    public hintApTrackingData: ApTrackingData
+    public hintApTrackingData: ApTrackingData,
+    public accessibleScopes: string[] = []
   ) {
     this.references = references;
     this.hintApTrackingData = hintApTrackingData;
@@ -33,6 +36,19 @@ export class IdsManager {
       this.hintApTrackingData,
       vm
     );
+  }
+
+  getConst(name: string, constants: Map<string, Felt>) {
+    if (!this.accessibleScopes.length) throw new EmptyAccessibleScope();
+    for (let i = this.accessibleScopes.length - 1; i >= 0; i--) {
+      const constant = constants.get(
+        this.accessibleScopes[i].concat('.', name)
+      );
+      if (constant) {
+        return constant;
+      }
+    }
+    throw new MissingConstant(name);
   }
 
   static getValueFromReference(

--- a/src/hints/idsManager.ts
+++ b/src/hints/idsManager.ts
@@ -7,6 +7,7 @@ import {
   UndefinedValue,
 } from 'errors/idsManager';
 import { ExpectedRelocatable } from 'errors/primitives';
+
 import { Felt } from 'primitives/felt';
 import { Relocatable } from 'primitives/relocatable';
 import { isRelocatable } from 'primitives/segmentValue';

--- a/src/hints/idsManager.ts
+++ b/src/hints/idsManager.ts
@@ -1,0 +1,134 @@
+import {
+  UndefinedVariable,
+  UndefinedImmediateRef,
+  InvalidValueType,
+  ApTrackingDataGroupDifferHintRef,
+  InvalidRegister,
+  UndefinedValue,
+} from 'errors/idsManager';
+import { ExpectedRelocatable } from 'errors/primitives';
+import { Felt } from 'primitives/felt';
+import { Relocatable } from 'primitives/relocatable';
+import { isRelocatable } from 'primitives/segmentValue';
+import { Register } from 'vm/instruction';
+import { ApTrackingData } from 'vm/program';
+import { VirtualMachine } from 'vm/virtualMachine';
+import { HintReference, ValueType, OffsetValue } from './hintReference';
+
+export class IdsManager {
+  constructor(
+    public references: Map<string, HintReference>,
+    public hintApTrackingData: ApTrackingData
+  ) {
+    this.references = references;
+    this.hintApTrackingData = hintApTrackingData;
+  }
+
+  get(name: string, vm: VirtualMachine) {
+    const reference = this.references.get(name);
+    if (!reference) throw new UndefinedVariable(name);
+    return IdsManager.getValueFromReference(
+      reference,
+      this.hintApTrackingData,
+      vm
+    );
+  }
+
+  static getValueFromReference(
+    reference: HintReference,
+    hintApTrackingData: ApTrackingData,
+    vm: VirtualMachine
+  ) {
+    const offset1 = reference.offset1;
+    switch (offset1.valueType) {
+      case ValueType.Immediate:
+        if (!offset1.immediate) throw new UndefinedImmediateRef(reference);
+        return offset1.immediate;
+      case ValueType.Reference:
+        const address = IdsManager.getAddressFromReference(
+          reference,
+          hintApTrackingData,
+          vm
+        );
+        if (!isRelocatable(address)) throw new ExpectedRelocatable(address);
+        if (reference.dereferenced) {
+          return vm.memory.get(address);
+        }
+        return address;
+      default:
+        throw new InvalidValueType(reference, offset1);
+    }
+  }
+
+  static getAddressFromReference(
+    reference: HintReference,
+    hintApTrackingData: ApTrackingData,
+    vm: VirtualMachine
+  ) {
+    const offset1 = reference.offset1;
+    const offset1Value = IdsManager.getOffsetValueReference(
+      offset1,
+      hintApTrackingData,
+      reference.apTrackingData,
+      vm
+    );
+    if (!offset1Value) throw new UndefinedValue(offset1);
+
+    let offsetValue = offset1Value;
+    const offset2 = reference.offset2;
+    if (offset2) {
+      switch (offset2.valueType) {
+        case ValueType.Value:
+          if (offset2.value === undefined) throw new UndefinedValue(offset2);
+          offsetValue = offset1Value.add(new Felt(BigInt(offset2.value)));
+          break;
+        case ValueType.Reference:
+          const offset2Value = IdsManager.getOffsetValueReference(
+            offset2,
+            hintApTrackingData,
+            reference.apTrackingData,
+            vm
+          );
+          if (!offset2Value) throw new UndefinedValue(offset2);
+          offsetValue = offset1Value.add(offset2Value);
+          break;
+        default:
+          throw new InvalidValueType(reference, offset2);
+      }
+    }
+    return offsetValue;
+  }
+
+  static getOffsetValueReference(
+    offset: OffsetValue,
+    hintApTrackingData: ApTrackingData,
+    refApTrackingData: ApTrackingData,
+    vm: VirtualMachine
+  ) {
+    let baseAddr: Relocatable;
+    switch (offset.register) {
+      case Register.Fp:
+        baseAddr = vm.fp;
+        break;
+      case Register.Ap:
+        if (refApTrackingData.group !== hintApTrackingData.group)
+          throw new ApTrackingDataGroupDifferHintRef(
+            hintApTrackingData.group,
+            refApTrackingData.group
+          );
+        baseAddr = vm.ap.sub(
+          hintApTrackingData.offset - refApTrackingData.offset
+        );
+        break;
+      default:
+        throw new InvalidRegister(offset, offset.register);
+    }
+    if (!baseAddr) throw new Error('');
+    if (offset.value === undefined) throw new UndefinedValue(offset);
+    const address = baseAddr.add(offset.value);
+    if (offset.dereferenced) {
+      return vm.memory.get(address);
+    }
+    return address;
+  }
+}

--- a/src/hints/idsManager.ts
+++ b/src/hints/idsManager.ts
@@ -140,7 +140,6 @@ export class IdsManager {
       default:
         throw new InvalidRegister(offset, offset.register);
     }
-    if (!baseAddr) throw new Error('');
     if (offset.value === undefined) throw new UndefinedValue(offset);
     const address = baseAddr.add(offset.value);
     if (offset.dereferenced) {

--- a/src/hints/scopeManager.test.ts
+++ b/src/hints/scopeManager.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { ScopeManager } from './scopeManager';
+import { CannotExitMainScope, VariableNotInScope } from 'errors/scopeManager';
+import { Felt } from 'primitives/felt';
+
+describe('ScopeManager', () => {
+  test('constructor', () => {
+    const scopeManager = new ScopeManager();
+    expect(scopeManager.data.length).toEqual(1);
+  });
+
+  test('should properly enter a new scope', () => {
+    const scopeManager = new ScopeManager();
+    scopeManager.enterScope({});
+    expect(scopeManager.data.length).toEqual(2);
+  });
+
+  test('should properly delete new scopes', () => {
+    const scopeManager = new ScopeManager();
+    scopeManager.enterScope({});
+    scopeManager.enterScope({});
+    scopeManager.exitScope();
+    expect(scopeManager.data.length).toEqual(2);
+  });
+
+  test.each([10, 'a', 4n, new Felt(3n), [1, 2, 3], { a: 3, b: [] }])(
+    'should properly set variables',
+    (value: any) => {
+      const scopeManager = new ScopeManager();
+      scopeManager.set('value', value);
+      expect(scopeManager.get('value')).toEqual(value);
+    }
+  );
+
+  test.each([10, 'a', 4n, new Felt(3n), [1, 2, 3], { a: 3, b: [] }])(
+    'should properly delete a defined variable',
+    (value) => {
+      const scopeManager = new ScopeManager();
+      expect(() => scopeManager.get('value')).toThrow(
+        new VariableNotInScope('value')
+      );
+      scopeManager.set('value', value);
+      expect(() => scopeManager.get('value')).not.toThrow();
+      scopeManager.delete('value');
+      expect(() => scopeManager.get('value')).toThrow(
+        new VariableNotInScope('value')
+      );
+    }
+  );
+
+  test('should throw if trying to delete main scope', () => {
+    const scopeManager = new ScopeManager();
+    expect(() => scopeManager.exitScope()).toThrow(new CannotExitMainScope());
+  });
+});

--- a/src/hints/scopeManager.ts
+++ b/src/hints/scopeManager.ts
@@ -1,0 +1,37 @@
+import { CannotExitMainScope, VariableNotInScope } from 'errors/scopeManager';
+
+export type Scope = {
+  [key: string]: any;
+};
+
+export class ScopeManager {
+  public data: Scope[];
+
+  constructor() {
+    this.data = [{}];
+  }
+
+  enterScope(newScope: Scope) {
+    this.data.push(newScope);
+  }
+
+  exitScope() {
+    if (this.data.length === 1) throw new CannotExitMainScope();
+    this.data.pop();
+  }
+
+  get(name: string) {
+    const variable = this.data[this.data.length - 1][name];
+    if (variable === undefined) throw new VariableNotInScope(name);
+    return variable;
+  }
+
+  set(name: string, value: any) {
+    this.data[this.data.length - 1][name] = value;
+  }
+
+  delete(name: string) {
+    const scope = this.data[this.data.length - 1];
+    delete scope[name];
+  }
+}

--- a/src/hints/scopeManager.ts
+++ b/src/hints/scopeManager.ts
@@ -1,9 +1,19 @@
 import { CannotExitMainScope, VariableNotInScope } from 'errors/scopeManager';
 
+/**
+ * A dictionnary mapping a variable name to its value,
+ * which can be anything
+ */
 export type Scope = {
   [key: string]: any;
 };
 
+/**
+ * A stack of Scope
+ * Scopes are used to share variables across hints
+ * Only the latest scope is available
+ * There is always one scope in the stack, the main scope
+ */
 export class ScopeManager {
   public data: Scope[];
 
@@ -11,25 +21,30 @@ export class ScopeManager {
     this.data = [{}];
   }
 
+  /** Add a new scope to the stack */
   enterScope(newScope: Scope) {
     this.data.push(newScope);
   }
 
+  /** Pop the stack */
   exitScope() {
     if (this.data.length === 1) throw new CannotExitMainScope();
     this.data.pop();
   }
 
+  /** Return the value of variable `name` in the latest scope */
   get(name: string) {
     const variable = this.data[this.data.length - 1][name];
     if (variable === undefined) throw new VariableNotInScope(name);
     return variable;
   }
 
+  /** Set the variable `name` to `value` in the latest scope */
   set(name: string, value: any) {
     this.data[this.data.length - 1][name] = value;
   }
 
+  /** Delete the variable `name` from the latest scope */
   delete(name: string) {
     const scope = this.data[this.data.length - 1];
     delete scope[name];

--- a/src/hints/scopeManager.ts
+++ b/src/hints/scopeManager.ts
@@ -46,7 +46,6 @@ export class ScopeManager {
 
   /** Delete the variable `name` from the latest scope */
   delete(name: string) {
-    const scope = this.data[this.data.length - 1];
-    delete scope[name];
+    delete this.data[this.data.length - 1][name];
   }
 }

--- a/src/hints/signature/ecdsa.ts
+++ b/src/hints/signature/ecdsa.ts
@@ -5,6 +5,15 @@ import { VirtualMachine } from 'vm/virtualMachine';
 import { EcdsaSegment } from 'builtins/ecdsa';
 import { IdsManager } from 'hints/idsManager';
 
+/**
+ * Hint to add an ECDSA signature to the
+ * `signatures` array of the ECDSA builtin
+ *
+ * Function linked to `ADD_ECDSA_SIGNATURE`:
+ * ```python
+ * %{ecdsa_builtin.add_signature(ids.ecdsa_ptr.address_, (ids.signature_r, ids.signature_s))}
+ * ```
+ */
 export function addECDSASignature(ids: IdsManager, vm: VirtualMachine) {
   const r = ids.get('signature_r', vm);
   const s = ids.get('signature_s', vm);

--- a/src/hints/signature/ecdsa.ts
+++ b/src/hints/signature/ecdsa.ts
@@ -1,0 +1,19 @@
+import { ExpectedFelt, ExpectedRelocatable } from 'errors/primitives';
+
+import { isFelt, isRelocatable } from 'primitives/segmentValue';
+import { VirtualMachine } from 'vm/virtualMachine';
+import { EcdsaSegment } from 'builtins/ecdsa';
+import { IdsManager } from 'hints/idsManager';
+
+export function addECDSASignature(ids: IdsManager, vm: VirtualMachine) {
+  const r = ids.get('signature_r', vm);
+  const s = ids.get('signature_s', vm);
+  const ecdsaPtr = ids.get('ecdsa_ptr', vm);
+  if (!r || !isFelt(r)) throw new ExpectedFelt(r);
+  if (!s || !isFelt(s)) throw new ExpectedFelt(s);
+  if (!ecdsaPtr || !isRelocatable(ecdsaPtr))
+    throw new ExpectedRelocatable(ecdsaPtr);
+
+  const ecdsaBuiltin = vm.memory.segments[ecdsaPtr.segmentId] as EcdsaSegment;
+  ecdsaBuiltin.signatures[ecdsaPtr.offset] = { r, s };
+}

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -10,6 +10,7 @@ import { Relocatable } from 'primitives/relocatable';
 import { parseProgram } from 'vm/program';
 import { CairoRunner, RunOptions } from './cairoRunner';
 import { RangeCheckOutOfBounds } from 'errors/builtins';
+import { EmptyRelocatedMemory } from 'errors/cairoRunner';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cairo-vm-ts-'));
 
@@ -133,6 +134,16 @@ describe('cairoRunner', () => {
           if (err) throw err;
         })
       ).not.toThrow();
+    });
+
+    test('should throw EmptyRelocatedMemory when exporting a non-relocated memory', () => {
+      const runner = new CairoRunner(FIBONACCI_PROGRAM);
+      runner.run();
+      const memoryFilename = 'fibonacci_memory_ts.bin';
+      const memoryPath = path.join(tmpDir, memoryFilename);
+      expect(() => runner.exportMemory(memoryPath)).toThrow(
+        new EmptyRelocatedMemory()
+      );
     });
 
     test('should export encoded memory', () => {

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -30,7 +30,6 @@ export class CairoRunner {
   programBase: Relocatable;
   executionBase: Relocatable;
   finalPc: Relocatable;
-  hintProcessor: HintProcessor;
 
   static readonly defaultRunOptions: RunOptions = {
     relocate: false,
@@ -43,7 +42,6 @@ export class CairoRunner {
     const mainOffset = mainId !== undefined ? mainId.pc ?? 0 : 0;
 
     const constants = extractConstants(program);
-    this.hintProcessor = new HintProcessor();
     const compiledHints = new CompiledHintData(
       Object.entries(program.hints).map(([offset, hints]) => [
         Number(offset),
@@ -76,7 +74,7 @@ export class CairoRunner {
    */
   run(config: RunOptions = CairoRunner.defaultRunOptions): void {
     while (!this.vm.pc.eq(this.finalPc)) {
-      this.vm.step(this.hintProcessor);
+      this.vm.step();
     }
     const { relocate, offset } = config;
     if (relocate) this.vm.relocate(offset);

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -34,7 +34,7 @@ export class CairoRunner {
     const mainId = program.identifiers.get('__main__.main');
     const mainOffset = mainId !== undefined ? mainId.pc ?? 0 : 0;
 
-    this.vm = new VirtualMachine();
+    this.vm = new VirtualMachine(program.hints);
     this.programBase = this.vm.memory.addSegment();
     this.executionBase = this.vm.memory.addSegment();
 

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -48,7 +48,7 @@ export class CairoRunner {
       Object.entries(program.hints).map(([offset, hints]) => [
         Number(offset),
         hints.map((hint) =>
-          this.hintProcessor.compile(hint, program.reference_manager)
+          HintProcessor.compile(hint, program.reference_manager)
         ),
       ])
     );
@@ -76,7 +76,7 @@ export class CairoRunner {
    */
   run(config: RunOptions = CairoRunner.defaultRunOptions): void {
     while (!this.vm.pc.eq(this.finalPc)) {
-      this.vm.step();
+      this.vm.step(this.hintProcessor);
     }
     const { relocate, offset } = config;
     if (relocate) this.vm.relocate(offset);

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -31,7 +31,7 @@ export class CairoRunner {
 
   constructor(program: Program) {
     this.program = program;
-    const mainId = program.identifiers.get('__main__.main');
+    const mainId = program.identifiers['__main__.main'];
     const mainOffset = mainId !== undefined ? mainId.pc ?? 0 : 0;
 
     this.vm = new VirtualMachine(program.hints);

--- a/src/vm/program.test.ts
+++ b/src/vm/program.test.ts
@@ -19,5 +19,17 @@ describe('program', () => {
       const program = parseProgram(programContent);
       expect(program.data).toEqual(data);
     });
+
+    test('parse program with hints', () => {
+      const programContent = fs.readFileSync(
+        'cairo_programs/cairo_0/ecdsa_builtin.json',
+        'utf8'
+      );
+      const programJson = JSON.parse(programContent);
+      const hints = programJson.hints;
+
+      const program = parseProgram(programContent);
+      expect(program.hints).toEqual(hints);
+    });
   });
 });

--- a/src/vm/program.ts
+++ b/src/vm/program.ts
@@ -34,9 +34,7 @@ const Identifier = z.object({
 
 const FlowTrackingData = z.object({
   ap_tracking: ApTrackingData,
-  reference_ids: z
-    .record(z.string(), z.number())
-    .transform((record) => new Map<string, number>(Object.entries(record))),
+  reference_ids: z.record(z.string(), z.number()),
 });
 
 const Hint = z.object({

--- a/src/vm/program.ts
+++ b/src/vm/program.ts
@@ -34,7 +34,9 @@ const Identifier = z.object({
 
 const FlowTrackingData = z.object({
   ap_tracking: ApTrackingData,
-  reference_ids: z.record(z.string(), z.number()),
+  reference_ids: z
+    .record(z.string(), z.number())
+    .transform((record) => new Map<string, number>(Object.entries(record))),
 });
 
 const Hint = z.object({
@@ -43,15 +45,17 @@ const Hint = z.object({
   flow_tracking_data: FlowTrackingData,
 });
 
+const Hints = z.record(z.string(), z.array(Hint));
+
 const Program = z.object({
   attributes: z.any(),
   builtins: z.array(z.string()),
   compiler_version: z.string(),
   data: z
     .array(z.string())
-    .transform((value) => value.map((v) => new Felt(BigInt(v)))),
+    .transform((values) => values.map((v) => new Felt(BigInt(v)))),
   debug_info: z.any(), // TODO: DebugInfo
-  hints: z.record(z.string(), z.array(Hint)),
+  hints: Hints,
   identifiers: z
     .record(z.string(), Identifier)
     .transform((record) => new Map<string, Identifier>(Object.entries(record))),
@@ -61,10 +65,12 @@ const Program = z.object({
 });
 
 type ReferenceManager = z.infer<typeof ReferenceManager>;
+export type Reference = z.infer<typeof Reference>;
 export type ApTrackingData = z.infer<typeof ApTrackingData>;
 export type Identifier = z.infer<typeof Identifier>;
 export type FlowTrackingData = z.infer<typeof FlowTrackingData>;
 export type Hint = z.infer<typeof Hint>;
+export type Hints = z.infer<typeof Hints>;
 export type Program = z.infer<typeof Program>;
 
 export function parseProgram(program: string): Program {

--- a/src/vm/program.ts
+++ b/src/vm/program.ts
@@ -74,14 +74,18 @@ export type FlowTrackingData = z.infer<typeof FlowTrackingData>;
 export type Hint = z.infer<typeof Hint>;
 export type Hints = z.infer<typeof Hints>;
 export type Program = z.infer<typeof Program>;
-export type ProgramConstants = Map<string, Felt>;
+export class ProgramConstants extends Map<string, Felt> {
+  constructor(values: Array<[string, Felt]> = []) {
+    super(values);
+  }
+}
 
 export function parseProgram(program: string): Program {
   return Program.parse(JSON.parse(program));
 }
 
 export function extractConstants(program: Program): ProgramConstants {
-  const constants: ProgramConstants = new Map<string, Felt>();
+  const constants: ProgramConstants = new ProgramConstants();
   Object.entries(program.identifiers).map(([name, identifier]) => {
     switch (identifier.type) {
       case 'const':

--- a/src/vm/program.ts
+++ b/src/vm/program.ts
@@ -17,8 +17,6 @@ const ReferenceManager = z.object({
   references: z.array(Reference),
 });
 
-type ReferenceManager = z.infer<typeof ReferenceManager>;
-
 const Identifier = z.object({
   full_name: z.string().optional(),
   members: z.record(z.string(), z.any()).optional(),
@@ -34,7 +32,16 @@ const Identifier = z.object({
   destination: z.string().optional(),
 });
 
-export type Identifier = z.infer<typeof Identifier>;
+const FlowTrackingData = z.object({
+  ap_tracking: ApTrackingData,
+  reference_ids: z.record(z.string(), z.number()),
+});
+
+const Hint = z.object({
+  accessible_scopes: z.array(z.string()),
+  code: z.string(),
+  flow_tracking_data: FlowTrackingData,
+});
 
 const Program = z.object({
   attributes: z.any(),
@@ -44,15 +51,20 @@ const Program = z.object({
     .array(z.string())
     .transform((value) => value.map((v) => new Felt(BigInt(v)))),
   debug_info: z.any(), // TODO: DebugInfo
-  hints: z.record(z.string(), z.any()), // TODO: HintParams
+  hints: z.record(z.string(), z.array(Hint)),
   identifiers: z
     .record(z.string(), Identifier)
-    .transform((value) => new Map<string, Identifier>(Object.entries(value))),
+    .transform((record) => new Map<string, Identifier>(Object.entries(record))),
   main_scope: z.string(),
   prime: z.string(),
   reference_manager: ReferenceManager,
 });
 
+type ReferenceManager = z.infer<typeof ReferenceManager>;
+export type ApTrackingData = z.infer<typeof ApTrackingData>;
+export type Identifier = z.infer<typeof Identifier>;
+export type FlowTrackingData = z.infer<typeof FlowTrackingData>;
+export type Hint = z.infer<typeof Hint>;
 export type Program = z.infer<typeof Program>;
 
 export function parseProgram(program: string): Program {

--- a/src/vm/program.ts
+++ b/src/vm/program.ts
@@ -80,10 +80,15 @@ export class ProgramConstants extends Map<string, Felt> {
   }
 }
 
+/** Parse the program compilation artifacts to a Program object */
 export function parseProgram(program: string): Program {
   return Program.parse(JSON.parse(program));
 }
 
+/**
+ *  Parse the program identifiers
+ * to return a map of constant name to their value
+ */
 export function extractConstants(program: Program): ProgramConstants {
   const constants: ProgramConstants = new ProgramConstants();
   Object.entries(program.identifiers).map(([name, identifier]) => {
@@ -109,6 +114,7 @@ export function extractConstants(program: Program): ProgramConstants {
   return constants;
 }
 
+/** Recursively find the root const of an alias */
 function findConstFromAlias(
   dest: string | undefined,
   identifiers: Identifiers

--- a/src/vm/program.ts
+++ b/src/vm/program.ts
@@ -74,13 +74,14 @@ export type FlowTrackingData = z.infer<typeof FlowTrackingData>;
 export type Hint = z.infer<typeof Hint>;
 export type Hints = z.infer<typeof Hints>;
 export type Program = z.infer<typeof Program>;
+export type ProgramConstants = Map<string, Felt>;
 
 export function parseProgram(program: string): Program {
   return Program.parse(JSON.parse(program));
 }
 
-export function extractConstants(program: Program) {
-  const constants = new Map<string, Felt>();
+export function extractConstants(program: Program): ProgramConstants {
+  const constants: ProgramConstants = new Map<string, Felt>();
   Object.entries(program.identifiers).map(([name, identifier]) => {
     switch (identifier.type) {
       case 'const':

--- a/src/vm/program.ts
+++ b/src/vm/program.ts
@@ -62,7 +62,7 @@ const Program = z.object({
   reference_manager: ReferenceManager,
 });
 
-type ReferenceManager = z.infer<typeof ReferenceManager>;
+export type ReferenceManager = z.infer<typeof ReferenceManager>;
 export type Reference = z.infer<typeof Reference>;
 export type ApTrackingData = z.infer<typeof ApTrackingData>;
 export type Identifier = z.infer<typeof Identifier>;

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -83,9 +83,7 @@ export class VirtualMachine {
   step(hintProcessor: HintProcessor = new HintProcessor()): void {
     const hints = this.hints.get(this.pc.offset);
     if (hints) {
-      hints.map((hint: HintData) =>
-        hintProcessor.execute(hint, this.constants, this)
-      );
+      hints.map((hint: HintData) => hintProcessor.execute(hint, this));
     }
 
     const maybeEncodedInstruction = this.memory.get(this.pc);

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -80,7 +80,7 @@ export class VirtualMachine {
    * - Decode the instruction at PC
    * - Run the instruction
    */
-  step(hintProcessor: HintProcessor = new HintProcessor()): void {
+  step(hintProcessor: HintProcessor): void {
     const hints = this.hints.get(this.pc.offset);
     if (hints) {
       hints.map((hint: HintData) => hintProcessor.execute(hint, this));

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -79,6 +79,7 @@ export class VirtualMachine {
 
   /**
    * Execute one step:
+   * - Execute the hints at PC
    * - Decode the instruction at PC
    * - Run the instruction
    */

--- a/src/vm/virtualMachine.ts
+++ b/src/vm/virtualMachine.ts
@@ -47,12 +47,13 @@ export type RelocatedMemory = {
 
 export class VirtualMachine {
   private currentStep: bigint;
-  constants: ProgramConstants;
-  hints: CompiledHintData;
   memory: Memory;
   pc: Relocatable;
   ap: Relocatable;
   fp: Relocatable;
+  constants: ProgramConstants;
+  hints: CompiledHintData;
+  hintProcessor: HintProcessor;
   trace: TraceEntry[];
   relocatedMemory: RelocatedMemory[];
   relocatedTrace: RelocatedTraceEntry[];
@@ -73,6 +74,7 @@ export class VirtualMachine {
 
     this.hints = hints;
     this.constants = constants;
+    this.hintProcessor = new HintProcessor();
   }
 
   /**
@@ -80,10 +82,10 @@ export class VirtualMachine {
    * - Decode the instruction at PC
    * - Run the instruction
    */
-  step(hintProcessor: HintProcessor): void {
+  step(): void {
     const hints = this.hints.get(this.pc.offset);
     if (hints) {
-      hints.map((hint: HintData) => hintProcessor.execute(hint, this));
+      hints.map((hint: HintData) => this.hintProcessor.execute(hint, this));
     }
 
     const maybeEncodedInstruction = this.memory.get(this.pc);


### PR DESCRIPTION
To implement hints, a few things are needed:

- A way to read variable used in hints (`ids.name`), managed by the `IdsManager` class.
This class relies on the `References` parsed from the `ReferenceManager` and the `Identifiers`, given in the compilation artifacts.

- Some hints use constants (or aliases to constants), fetched from the compilation artifact by the `extractConstants` method. (e.g. BigStruct using SquashedDict that are not implemented yet)

When instantiating the CairoRunner, the constants are extracted and the hints are transformed into an exploitable format to be stored as VirtualMachine attributes. 

 Some hints are using data from other hints, the ScopeManager is a stack of dictionaries (scopes) which allows sharing data across hints.

There still needs to add JSDoc and a few util methods might be implemented later on if a group of hints needs it.
At the moment it works but it might not be following our coding guidelines, parts might/should be refactored