### PR TITLE
feat: add layouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,13 @@ compile: compile-cairo-zero compile-cairo
 
 
 
-run-all: $(VALID_COMPILED_CAIRO_0_FILES)
+run-all: $(VALID_COMPILED_CAIRO_0_FILES) $(COMPILED_CAIRO_FILES)
 	@failed_tests_ctr=0; \
 	failed_tests=""; \
 	passed_tests_ctr=0; \
 	for file in $^; do \
 		echo "Running $$file..."; \
-		cairo run -s $$file; \
+		cairo run -s -l all_cairo $$file; \
 		exit_code=$$?; \
 		if [ $$exit_code -ne 0 ]; then \
 			failed_tests_ctr=$$((failed_tests_ctr + 1)); \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ $(CAIRO_VM_RS_CLI):
 
 $(CAIRO_VM_ZIG_CLI):
 	@git submodule update --init ziggy-starkdust \
-	cd ziggy-starkdust; zig build
+	cd ziggy-starkdust; zig build -Doptimize=ReleaseFast
 
 build:
 	@bun install; bun link

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You can still add it as a dependency with a local copy:
 | Goals                        | Done?   |
 | ---------------------------- | ------- |
 | Run basic Cairo Zero program | &#9745; |
-| Run basic Cairo program      | &#9744; |
+| Run basic Cairo program      | &#9745; |
 | Add [builtins](#builtins)    | &#9745; |
 | Add [hints](#hints)          | &#9744; |
 | Run StarkNet contracts       | &#9744; |

--- a/cairo_programs/cairo/hints/test_less_than_args.cairo
+++ b/cairo_programs/cairo/hints/test_less_than_args.cairo
@@ -1,3 +1,0 @@
-fn main(a: u32, b: u32, c: u32) {
-    (a < b, b < c);
-}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,10 +31,12 @@ program
   )
   .option('-s, --silent', 'silent all logs')
   .addOption(
-    new Option('--layout <LAYOUT>', 'Layout to be used').default('plain')
+    new Option('-l, --layout <LAYOUT>', 'Layout to be used').default('plain')
   )
   .addOption(
-    new Option('--fn <NAME>', 'Function to be executed').default('main')
+    new Option('-f, --function <NAME>', 'Function to be executed').default(
+      'main'
+    )
   )
   .option('--no-relocate', 'do not relocate memory')
   .addOption(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,9 @@ program
   )
   .option('-s, --silent', 'silent all logs')
   .addOption(
+    new Option('--layout <LAYOUT>', 'Layout to be used').default('plain')
+  )
+  .addOption(
     new Option('--fn <NAME>', 'Function to be executed').default('main')
   )
   .option('--no-relocate', 'do not relocate memory')

--- a/src/errors/cairoRunner.ts
+++ b/src/errors/cairoRunner.ts
@@ -29,7 +29,7 @@ export class UndefinedEntrypoint extends CairoRunnerError {
 }
 
 /** The program builtins are not a subsequence of the builtins available in the chosen layout. */
-export class UnorderedBuiltins extends CairoRunnerError {
+export class InvalidBuiltins extends CairoRunnerError {
   constructor(
     programBuiltins: string[],
     layoutBuiltins: string[],

--- a/src/errors/cairoRunner.ts
+++ b/src/errors/cairoRunner.ts
@@ -27,3 +27,23 @@ export class UndefinedEntrypoint extends CairoRunnerError {
     super(`The function to be executed doesn't exist: ${name}`);
   }
 }
+
+/** The program builtins has builtins that are not available in the chosen layout. */
+export class InvalidBuiltins extends CairoRunnerError {
+  constructor(builtins: string[], layout: string) {
+    super(
+      `The program contains builtins that are not supported by the layout ${layout}: ${builtins.join(
+        ', '
+      )}. Choose another layout to execute this program.`
+    );
+  }
+}
+
+/** The program builtins are not ordered as a subsequence of the builtins available in the layout. */
+export class UnorderedBuiltins extends CairoRunnerError {
+  constructor() {
+    super(
+      'The program builtins are not in the right order. It must follow the layout order.'
+    );
+  }
+}

--- a/src/errors/cairoRunner.ts
+++ b/src/errors/cairoRunner.ts
@@ -28,22 +28,17 @@ export class UndefinedEntrypoint extends CairoRunnerError {
   }
 }
 
-/** The program builtins has builtins that are not available in the chosen layout. */
-export class InvalidBuiltins extends CairoRunnerError {
-  constructor(builtins: string[], layout: string) {
-    super(
-      `The program contains builtins that are not supported by the layout ${layout}: ${builtins.join(
-        ', '
-      )}. Choose another layout to execute this program.`
-    );
-  }
-}
-
-/** The program builtins are not ordered as a subsequence of the builtins available in the layout. */
+/** The program builtins are not a subsequence of the builtins available in the chosen layout. */
 export class UnorderedBuiltins extends CairoRunnerError {
-  constructor() {
+  constructor(
+    programBuiltins: string[],
+    layoutBuiltins: string[],
+    layout: string
+  ) {
     super(
-      'The program builtins are not in the right order. It must follow the layout order.'
+      `The program builtins are not a subsequence of the '${layout}' layout builtins.
+Program builtins: ${programBuiltins.join(', ')}
+Layout builtins: ${layoutBuiltins.join(', ')}`
     );
   }
 }

--- a/src/errors/cairoRunner.ts
+++ b/src/errors/cairoRunner.ts
@@ -14,13 +14,6 @@ export class CairoZeroHintsNotSupported extends CairoRunnerError {
   }
 }
 
-/** The output serialization of Cairo programs is not supported. */
-export class CairoOutputNotSupported extends CairoRunnerError {
-  constructor() {
-    super('The output serialization of Cairo programs is not supported yet.');
-  }
-}
-
 /** The given entrypoint is not in the program, it cannot be executed. */
 export class UndefinedEntrypoint extends CairoRunnerError {
   constructor(name: string) {

--- a/src/errors/cairoRunner.ts
+++ b/src/errors/cairoRunner.ts
@@ -1,23 +1,27 @@
 class CairoRunnerError extends Error {}
 
+/** The relocated memory is empty. It cannot be exported. */
 export class EmptyRelocatedMemory extends CairoRunnerError {
   constructor() {
     super('Relocated memory is empty');
   }
 }
 
+/** The Cairo Zero hints are not supported. */
 export class CairoZeroHintsNotSupported extends CairoRunnerError {
   constructor() {
     super('Cairo Zero hints are not supported yet.');
   }
 }
 
+/** The output serialization of Cairo programs is not supported. */
 export class CairoOutputNotSupported extends CairoRunnerError {
   constructor() {
     super('The output serialization of Cairo programs is not supported yet.');
   }
 }
 
+/** The given entrypoint is not in the program, it cannot be executed. */
 export class UndefinedEntrypoint extends CairoRunnerError {
   constructor(name: string) {
     super(`The function to be executed doesn't exist: ${name}`);

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -154,7 +154,7 @@ describe('cairoRunner', () => {
   describe('builtins', () => {
     describe('bitwise', () => {
       test('should compute bitwise operations 12 & 10, 12 ^10 and 12 | 10', () => {
-        const runner = CairoRunner.fromProgram(BITWISE_PROGRAM);
+        const runner = CairoRunner.fromProgram(BITWISE_PROGRAM, 'all_cairo');
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
         const executionSize = runner.vm.memory.getSegmentSize(1);
@@ -169,7 +169,7 @@ describe('cairoRunner', () => {
 
     describe('ec_op', () => {
       test('should properly compute  R = P + 34Q', () => {
-        const runner = CairoRunner.fromProgram(EC_OP_PROGRAM);
+        const runner = CairoRunner.fromProgram(EC_OP_PROGRAM, 'all_cairo');
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
 
@@ -189,7 +189,7 @@ describe('cairoRunner', () => {
 
     describe('pedersen', () => {
       test('should properly compute Pedersen hashes of (0, 0), (0, 1), (1, 0) and (54, 1249832432) tuples', () => {
-        const runner = CairoRunner.fromProgram(PEDERSEN_PROGRAM);
+        const runner = CairoRunner.fromProgram(PEDERSEN_PROGRAM, 'all_cairo');
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
 
@@ -218,7 +218,7 @@ describe('cairoRunner', () => {
 
     describe('poseidon', () => {
       test('should properly compute Poseidon states from initial states (1, 2, 3) and (13, 40, 36)', () => {
-        const runner = CairoRunner.fromProgram(POSEIDON_PROGRAM);
+        const runner = CairoRunner.fromProgram(POSEIDON_PROGRAM, 'all_cairo');
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
 
@@ -262,7 +262,10 @@ describe('cairoRunner', () => {
 
     describe('keccak', () => {
       test('Should properly compute state from input state KeccakBuiltinState(0, 0, 0, 0, 0, 0, 0, 0)', () => {
-        const runner = CairoRunner.fromProgram(KECCAK_SEED_PROGRAM);
+        const runner = CairoRunner.fromProgram(
+          KECCAK_SEED_PROGRAM,
+          'all_cairo'
+        );
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
 
@@ -288,7 +291,7 @@ describe('cairoRunner', () => {
       });
 
       test('Should properly compute state from input state KeccakBuiltinState(1, 2, 3, 4, 5, 6, 7, 8)', () => {
-        const runner = CairoRunner.fromProgram(KECCAK_PROGRAM);
+        const runner = CairoRunner.fromProgram(KECCAK_PROGRAM, 'all_cairo');
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
 
@@ -316,7 +319,7 @@ describe('cairoRunner', () => {
 
     describe('output', () => {
       test('Should properly store the jmp dest value in the output segment', () => {
-        const runner = CairoRunner.fromProgram(JMP_PROGRAM);
+        const runner = CairoRunner.fromProgram(JMP_PROGRAM, 'small');
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
         const output = runner.getOutput();
@@ -325,7 +328,10 @@ describe('cairoRunner', () => {
       });
 
       test('Should properly write the result of bitwise 1 & 2 to output segment', () => {
-        const runner = CairoRunner.fromProgram(BITWISE_OUTPUT_PROGRAM);
+        const runner = CairoRunner.fromProgram(
+          BITWISE_OUTPUT_PROGRAM,
+          'all_cairo'
+        );
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
         const output = runner.getOutput();
@@ -336,7 +342,10 @@ describe('cairoRunner', () => {
 
     describe('range_check', () => {
       test('should properly write 2 ** 128 - 1 to the range check segment', () => {
-        const runner = CairoRunner.fromProgram(RANGE_CHECK_PROGRAM);
+        const runner = CairoRunner.fromProgram(
+          RANGE_CHECK_PROGRAM,
+          'all_cairo'
+        );
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
         const executionSize = runner.vm.memory.getSegmentSize(1);
@@ -347,7 +356,10 @@ describe('cairoRunner', () => {
       });
 
       test('should crash the VM when trying to assert -1 to the range check segment', () => {
-        const runner = CairoRunner.fromProgram(BAD_RANGE_CHECK_PROGRAM);
+        const runner = CairoRunner.fromProgram(
+          BAD_RANGE_CHECK_PROGRAM,
+          'all_cairo'
+        );
         const config: RunOptions = { relocate: true, offset: 1 };
         expect(() => runner.run(config)).toThrow(
           new RangeCheckOutOfBounds(new Felt(-1n), 128n)
@@ -357,7 +369,10 @@ describe('cairoRunner', () => {
 
     describe('range_check96', () => {
       test('should properly write 2 ** 96 - 1 to the range check segment', () => {
-        const runner = CairoRunner.fromProgram(RANGE_CHECK96_PROGRAM);
+        const runner = CairoRunner.fromProgram(
+          RANGE_CHECK96_PROGRAM,
+          'all_cairo'
+        );
         const config: RunOptions = { relocate: true, offset: 1 };
         runner.run(config);
         const executionSize = runner.vm.memory.getSegmentSize(1);
@@ -368,7 +383,10 @@ describe('cairoRunner', () => {
       });
 
       test('should crash the VM when trying to assert 2 ** 96 to the range check segment', () => {
-        const runner = CairoRunner.fromProgram(BAD_RANGE_CHECK96_PROGRAM);
+        const runner = CairoRunner.fromProgram(
+          BAD_RANGE_CHECK96_PROGRAM,
+          'all_cairo'
+        );
         const config: RunOptions = { relocate: true, offset: 1 };
         expect(() => runner.run(config)).toThrow(
           new RangeCheckOutOfBounds(new Felt(2n ** 96n), 96n)

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -447,18 +447,9 @@ describe('cairoRunner', () => {
         const dummyProgram = parseProgram(
           fs.readFileSync('cairo_programs/cairo_0/fibonacci.json', 'utf-8')
         );
-        const dummyBytecode: Felt[] = [];
-        const dummyPc = 0;
 
         expect(
-          () =>
-            new CairoRunner(
-              dummyProgram,
-              dummyBytecode,
-              layout,
-              dummyPc,
-              builtins
-            )
+          () => new CairoRunner(dummyProgram, [], layout, 'main', 0, builtins)
         ).not.toThrow();
       }
     );
@@ -475,18 +466,9 @@ describe('cairoRunner', () => {
         const dummyProgram = parseProgram(
           fs.readFileSync('cairo_programs/cairo_0/fibonacci.json', 'utf-8')
         );
-        const dummyBytecode: Felt[] = [];
-        const dummyPc = 0;
 
         expect(
-          () =>
-            new CairoRunner(
-              dummyProgram,
-              dummyBytecode,
-              layout,
-              dummyPc,
-              builtins
-            )
+          () => new CairoRunner(dummyProgram, [], layout, 'main', 0, builtins)
         ).toThrow(
           new InvalidBuiltins(builtins, layouts[layout].builtins, layout)
         );

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -456,6 +456,9 @@ describe('cairoRunner', () => {
       [['output', 'pedersen'], 'small'],
       [['output', 'pedersen', 'range_check'], 'small'],
       [['output', 'range_check', 'poseidon'], 'starknet'],
+      [['output', 'range_check', 'segment_arena'], 'all_cairo'],
+      [['output', 'range_check', 'gas_builtin'], 'all_cairo'],
+      [['output', 'range_check', 'system'], 'starknet'],
     ])(
       'should correctly parse a program with an appropriate layout',
       (builtins, layout) => {
@@ -475,6 +478,7 @@ describe('cairoRunner', () => {
       [['output', 'range_check', 'pedersen'], 'small'],
       [['output', 'pedersen', 'range_check', 'ecdsa', 'ec_op'], 'small'],
       [['output', 'range_check', 'poseidon', 'range_check96'], 'starknet'],
+      [['output', 'segment_arena', 'range_check'], 'all_cairo'],
     ])(
       'should throw InvalidBuiltins if builtins are not within the layout or unordered',
       (builtins, layout) => {

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -464,7 +464,7 @@ describe('cairoRunner', () => {
         );
 
         expect(
-          () => new CairoRunner(dummyProgram, [], layout, 'main', 0, builtins)
+          () => new CairoRunner(dummyProgram, [], layout, 0, builtins)
         ).not.toThrow();
       }
     );
@@ -483,7 +483,7 @@ describe('cairoRunner', () => {
         );
 
         expect(
-          () => new CairoRunner(dummyProgram, [], layout, 'main', 0, builtins)
+          () => new CairoRunner(dummyProgram, [], layout, 0, builtins)
         ).toThrow(
           new InvalidBuiltins(builtins, layouts[layout].builtins, layout)
         );

--- a/src/runners/cairoRunner.test.ts
+++ b/src/runners/cairoRunner.test.ts
@@ -455,10 +455,11 @@ describe('cairoRunner', () => {
       [['bitwise'], 'recursive'],
       [['output', 'pedersen'], 'small'],
       [['output', 'pedersen', 'range_check'], 'small'],
+      [['pedersen', 'range_check'], 'small'],
       [['output', 'range_check', 'poseidon'], 'starknet'],
       [['output', 'range_check', 'segment_arena'], 'all_cairo'],
-      [['output', 'range_check', 'gas_builtin'], 'all_cairo'],
-      [['output', 'range_check', 'system'], 'starknet'],
+      [['range_check', 'gas_builtin'], 'all_cairo'],
+      [['output', 'range_check', 'segment_arena', 'system'], 'starknet'],
     ])(
       'should correctly parse a program with an appropriate layout',
       (builtins, layout) => {
@@ -479,6 +480,7 @@ describe('cairoRunner', () => {
       [['output', 'pedersen', 'range_check', 'ecdsa', 'ec_op'], 'small'],
       [['output', 'range_check', 'poseidon', 'range_check96'], 'starknet'],
       [['output', 'segment_arena', 'range_check'], 'all_cairo'],
+      [['output', 'range_check', 'gas_builtin', 'segment_arena'], 'all_cairo'],
     ])(
       'should throw InvalidBuiltins if builtins are not within the layout or unordered',
       (builtins, layout) => {

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -56,7 +56,7 @@ export class CairoRunner {
 
     const layout = layouts[layoutName];
     const invalidBuiltins = builtins.filter(
-      (builtin) => builtin in layout.builtins
+      (builtin) => layout.builtins.findIndex((name) => builtin === name) === -1
     );
     if (invalidBuiltins.length)
       throw new InvalidBuiltins(invalidBuiltins, layoutName);

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -56,7 +56,7 @@ export class CairoRunner {
 
     const layout = layouts[layoutName];
     const invalidBuiltins = builtins.filter(
-      (builtin) => layout.builtins.findIndex((name) => builtin === name) === -1
+      (builtin) => !layout.builtins.includes(builtin)
     );
     if (invalidBuiltins.length)
       throw new InvalidBuiltins(invalidBuiltins, layoutName);

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -34,7 +34,6 @@ export class CairoRunner {
   executionBase: Relocatable;
   layout: Layout;
   builtins: string[];
-  entrypoint: string;
   finalPc: Relocatable;
 
   static readonly defaultRunOptions: RunOptions = {
@@ -46,7 +45,6 @@ export class CairoRunner {
     program: Program,
     bytecode: Felt[],
     layoutName: string = 'plain',
-    entrypoint: string = 'main',
     initialPc: number = 0,
     builtins: string[] = [],
     hints: Hints = new Map<number, Hint[]>()
@@ -57,7 +55,6 @@ export class CairoRunner {
     this.programBase = this.vm.memory.addSegment();
     this.executionBase = this.vm.memory.addSegment();
 
-    this.entrypoint = entrypoint;
     this.layout = layouts[layoutName];
     if (!isSubsequence(builtins, this.layout.builtins))
       throw new InvalidBuiltins(builtins, this.layout.builtins, layoutName);
@@ -91,14 +88,7 @@ export class CairoRunner {
 
     if (program.hints.length) throw new CairoZeroHintsNotSupported();
 
-    return new CairoRunner(
-      program,
-      program.data,
-      layoutName,
-      fnName,
-      offset,
-      builtins
-    );
+    return new CairoRunner(program, program.data, layoutName, offset, builtins);
   }
 
   static fromCairoProgram(
@@ -112,7 +102,6 @@ export class CairoRunner {
       program,
       program.bytecode,
       layoutName,
-      fnName,
       fn.offset,
       fn.builtins,
       program.hints

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -14,7 +14,7 @@ import { CairoProgram, CairoZeroProgram, Program } from 'vm/program';
 import { VirtualMachine } from 'vm/virtualMachine';
 import { getBuiltin } from 'builtins/builtin';
 import { Hint, Hints } from 'hints/hintSchema';
-import { isSubsequence, layouts } from './layout';
+import { isSubsequence, Layout, layouts } from './layout';
 
 /**
  * Configuration of the run
@@ -28,6 +28,7 @@ export type RunOptions = {
 
 export class CairoRunner {
   program: Program;
+  layout: Layout;
   hints: Hints;
   vm: VirtualMachine;
   programBase: Relocatable;
@@ -53,9 +54,9 @@ export class CairoRunner {
     this.programBase = this.vm.memory.addSegment();
     this.executionBase = this.vm.memory.addSegment();
 
-    const layout = layouts[layoutName];
-    if (!isSubsequence(builtins, layout.builtins))
-      throw new UnorderedBuiltins(builtins, layout.builtins, layoutName);
+    this.layout = layouts[layoutName];
+    if (!isSubsequence(builtins, this.layout.builtins))
+      throw new UnorderedBuiltins(builtins, this.layout.builtins, layoutName);
 
     const builtin_stack = builtins
       .map(getBuiltin)

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -80,6 +80,7 @@ export class CairoRunner {
     this.vm.memory.setValues(this.executionBase, stack);
   }
 
+  /** Instantiate a CairoRunner from parsed Cairo Zero compilation artifacts. */
   static fromCairoZeroProgram(
     program: CairoZeroProgram,
     layoutName: string = 'plain',
@@ -96,6 +97,7 @@ export class CairoRunner {
     return new CairoRunner(program, program.data, layoutName, offset, builtins);
   }
 
+  /** Instantiate a CairoRunner from parsed Cairo compilation artifacts. */
   static fromCairoProgram(
     program: CairoProgram,
     layoutName: string = 'plain',
@@ -113,6 +115,7 @@ export class CairoRunner {
     );
   }
 
+  /** Instantiate a CairoRunner from any Cairo or Cairo Zero compilation artifacts. */
   static fromProgram(
     program: Program,
     layout: string = 'plain',

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -4,7 +4,6 @@ import {
   CairoOutputNotSupported,
   CairoZeroHintsNotSupported,
   EmptyRelocatedMemory,
-  InvalidBuiltins,
   UndefinedEntrypoint,
   UnorderedBuiltins,
 } from 'errors/cairoRunner';
@@ -55,13 +54,8 @@ export class CairoRunner {
     this.executionBase = this.vm.memory.addSegment();
 
     const layout = layouts[layoutName];
-    const invalidBuiltins = builtins.filter(
-      (builtin) => !layout.builtins.includes(builtin)
-    );
-    if (invalidBuiltins.length)
-      throw new InvalidBuiltins(invalidBuiltins, layoutName);
     if (!isSubsequence(builtins, layout.builtins))
-      throw new UnorderedBuiltins();
+      throw new UnorderedBuiltins(builtins, layout.builtins, layoutName);
 
     const builtin_stack = builtins
       .map(getBuiltin)

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -201,13 +201,7 @@ export class CairoRunner {
     return this.vm.memory.segments[builtinId + offset];
   }
 
-  /**
-   * @returns The output builtin segment.
-   *
-   * NOTE: Currently supports Cairo Zero programs only.
-   * Cairo programs need input args/return value logic to be implemented first.
-   *
-   */
+  /** @returns The output builtin segment. */
   getOutput() {
     return this.getBuiltinSegment('output') ?? [];
   }

--- a/src/runners/cairoRunner.ts
+++ b/src/runners/cairoRunner.ts
@@ -5,7 +5,7 @@ import {
   CairoZeroHintsNotSupported,
   EmptyRelocatedMemory,
   UndefinedEntrypoint,
-  UnorderedBuiltins,
+  InvalidBuiltins,
 } from 'errors/cairoRunner';
 
 import { Felt } from 'primitives/felt';
@@ -56,7 +56,7 @@ export class CairoRunner {
 
     this.layout = layouts[layoutName];
     if (!isSubsequence(builtins, this.layout.builtins))
-      throw new UnorderedBuiltins(builtins, this.layout.builtins, layoutName);
+      throw new InvalidBuiltins(builtins, this.layout.builtins, layoutName);
 
     const builtin_stack = builtins
       .map(getBuiltin)

--- a/src/runners/layout.test.ts
+++ b/src/runners/layout.test.ts
@@ -8,18 +8,38 @@ import {
 
 describe('layouts', () => {
   describe('Layout', () => {
+    test('plain layout should the right values', () => {
+      const plain = layouts['plain'];
+      expect(plain.builtins).toEqual([]);
+      expect(plain.rcUnits).toEqual(16);
+      expect(plain.publicMemoryFraction).toEqual(4);
+      expect(plain.dilutedPool).toBeUndefined();
+      expect(plain.ratios).toBeUndefined();
+    });
     test.each([
-      ['plain', [], 16, 4],
-      ['small', ['output', 'pedersen', 'range_check', 'ecdsa'], 16, 4],
-      ['dex', ['output', 'pedersen', 'range_check', 'ecdsa'], 4, 4],
+      [
+        'small',
+        ['output', 'pedersen', 'range_check', 'ecdsa'],
+        16,
+        4,
+        { pedersen: 8, range_check: 8, ecdsa: 512 },
+      ],
+      [
+        'dex',
+        ['output', 'pedersen', 'range_check', 'ecdsa'],
+        4,
+        4,
+        { pedersen: 8, range_check: 8, ecdsa: 512 },
+      ],
     ])(
       'should have the correct values with undefined DilutedPool',
-      (layoutName, builtins, rcUnits, publicMemoryFraction) => {
+      (layoutName, builtins, rcUnits, publicMemoryFraction, ratios) => {
         const layout = layouts[layoutName];
         expect(layout.builtins).toEqual(builtins);
         expect(layout.rcUnits).toEqual(rcUnits);
         expect(layout.publicMemoryFraction).toEqual(publicMemoryFraction);
         expect(layout.dilutedPool).toBeUndefined();
+        expect(layout.ratios).toEqual(ratios);
       }
     );
 
@@ -40,6 +60,11 @@ describe('layouts', () => {
         4,
         8,
         DEFAULT_DILUTED_POOL,
+        {
+          pedersen: 128,
+          range_check: 8,
+          bitwise: 8,
+        },
       ],
       [
         'starknet',
@@ -59,6 +84,14 @@ describe('layouts', () => {
           spacing: 4,
           nBits: 16,
         },
+        {
+          pedersen: 32,
+          range_check: 16,
+          ecdsa: 2048,
+          bitwise: 64,
+          ec_op: 1024,
+          poseidon: 32,
+        },
       ],
       [
         'starknet_with_keccak',
@@ -75,6 +108,15 @@ describe('layouts', () => {
         4,
         8,
         DEFAULT_DILUTED_POOL,
+        {
+          pedersen: 32,
+          range_check: 16,
+          ecdsa: 2048,
+          bitwise: 64,
+          ec_op: 1024,
+          keccak: 2048,
+          poseidon: 32,
+        },
       ],
       [
         'recursive_large_output',
@@ -82,6 +124,12 @@ describe('layouts', () => {
         4,
         8,
         DEFAULT_DILUTED_POOL,
+        {
+          pedersen: 128,
+          range_check: 8,
+          bitwise: 8,
+          poseidon: 8,
+        },
       ],
       [
         'recursive_with_poseidon',
@@ -92,6 +140,12 @@ describe('layouts', () => {
           unitsPerStep: 8,
           spacing: 4,
           nBits: 16,
+        },
+        {
+          pedersen: 256,
+          range_check: 16,
+          bitwise: 16,
+          poseidon: 64,
         },
       ],
       [
@@ -110,6 +164,16 @@ describe('layouts', () => {
         4,
         8,
         DEFAULT_DILUTED_POOL,
+        {
+          pedersen: 256,
+          range_check: 8,
+          ecdsa: 2048,
+          bitwise: 16,
+          ec_op: 1024,
+          keccak: 2048,
+          poseidon: 256,
+          range_check96: 8,
+        },
       ],
       [
         'all_solidity',
@@ -117,22 +181,38 @@ describe('layouts', () => {
         8,
         8,
         DEFAULT_DILUTED_POOL,
+        {
+          pedersen: 8,
+          range_check: 8,
+          ecdsa: 512,
+          bitwise: 256,
+          ec_op: 256,
+        },
       ],
-      ['dynamic', ['output'], 16, 8, DEFAULT_DILUTED_POOL],
+      [
+        'dynamic',
+        ['output', 'pedersen', 'range_check', 'ecdsa', 'bitwise', 'ec_op'],
+        16,
+        8,
+        DEFAULT_DILUTED_POOL,
+        {},
+      ],
     ])(
-      'should have the correct values with a defined DilutedPool',
+      'should have the correct values with a defined DilutedPool and ratios',
       (
         layoutName: string,
         builtins: string[],
         rcUnits: number,
         publicMemoryFraction: number,
-        dilutedPool: DilutedPool
+        dilutedPool: DilutedPool,
+        ratios: { [key: string]: number }
       ) => {
         const layout = layouts[layoutName];
         expect(layout.builtins).toEqual(builtins);
         expect(layout.rcUnits).toEqual(rcUnits);
         expect(layout.publicMemoryFraction).toEqual(publicMemoryFraction);
         expect(layout.dilutedPool).toEqual(dilutedPool);
+        expect(layout.ratios).toEqual(ratios);
       }
     );
   });

--- a/src/runners/layout.test.ts
+++ b/src/runners/layout.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_DILUTED_POOL,
+  DilutedPool,
+  isSubsequence,
+  layouts,
+} from './layout';
+
+describe('layouts', () => {
+  describe('Layout', () => {
+    test.each([
+      ['plain', [], 16, 4],
+      ['small', ['output', 'pedersen', 'range_check', 'ecdsa'], 16, 4],
+      ['dex', ['output', 'pedersen', 'range_check', 'ecdsa'], 4, 4],
+    ])(
+      'should have the correct values with undefined DilutedPool',
+      (layoutName, builtins, rcUnits, publicMemoryFraction) => {
+        const layout = layouts[layoutName];
+        expect(layout.builtins).toEqual(builtins);
+        expect(layout.rcUnits).toEqual(rcUnits);
+        expect(layout.publicMemoryFraction).toEqual(publicMemoryFraction);
+        expect(layout.dilutedPool).toBeUndefined();
+      }
+    );
+
+    test('DEFAULT_DILUTED_POOL should have the expected values', () => {
+      const expectedDefaultDilutedPool: DilutedPool = {
+        unitsPerStep: 16,
+        spacing: 4,
+        nBits: 16,
+      };
+
+      expect(DEFAULT_DILUTED_POOL).toEqual(expectedDefaultDilutedPool);
+    });
+
+    test.each([
+      [
+        'recursive',
+        ['output', 'pedersen', 'range_check', 'bitwise'],
+        4,
+        8,
+        DEFAULT_DILUTED_POOL,
+      ],
+      [
+        'starknet',
+        [
+          'output',
+          'pedersen',
+          'range_check',
+          'ecdsa',
+          'bitwise',
+          'ec_op',
+          'poseidon',
+        ],
+        4,
+        8,
+        {
+          unitsPerStep: 2,
+          spacing: 4,
+          nBits: 16,
+        },
+      ],
+      [
+        'starknet_with_keccak',
+        [
+          'output',
+          'pedersen',
+          'range_check',
+          'ecdsa',
+          'bitwise',
+          'ec_op',
+          'keccak',
+          'poseidon',
+        ],
+        4,
+        8,
+        DEFAULT_DILUTED_POOL,
+      ],
+      [
+        'recursive_large_output',
+        ['output', 'pedersen', 'range_check', 'bitwise', 'poseidon'],
+        4,
+        8,
+        DEFAULT_DILUTED_POOL,
+      ],
+      [
+        'recursive_with_poseidon',
+        ['output', 'pedersen', 'range_check', 'bitwise', 'poseidon'],
+        4,
+        8,
+        {
+          unitsPerStep: 8,
+          spacing: 4,
+          nBits: 16,
+        },
+      ],
+      [
+        'all_cairo',
+        [
+          'output',
+          'pedersen',
+          'range_check',
+          'ecdsa',
+          'bitwise',
+          'ec_op',
+          'keccak',
+          'poseidon',
+          'range_check96',
+        ],
+        4,
+        8,
+        DEFAULT_DILUTED_POOL,
+      ],
+      [
+        'all_solidity',
+        ['output', 'pedersen', 'range_check', 'ecdsa', 'bitwise', 'ec_op'],
+        8,
+        8,
+        DEFAULT_DILUTED_POOL,
+      ],
+      ['dynamic', ['output'], 16, 8, DEFAULT_DILUTED_POOL],
+    ])(
+      'should have the correct values with a defined DilutedPool',
+      (
+        layoutName: string,
+        builtins: string[],
+        rcUnits: number,
+        publicMemoryFraction: number,
+        dilutedPool: DilutedPool
+      ) => {
+        const layout = layouts[layoutName];
+        expect(layout.builtins).toEqual(builtins);
+        expect(layout.rcUnits).toEqual(rcUnits);
+        expect(layout.publicMemoryFraction).toEqual(publicMemoryFraction);
+        expect(layout.dilutedPool).toEqual(dilutedPool);
+      }
+    );
+  });
+
+  describe('isSubsequence', () => {
+    test.each([
+      [
+        ['output', 'pedersen', 'range_check'],
+        ['output', 'pedersen', 'range_check', 'ecdsa'],
+        true,
+      ],
+      [
+        ['output', 'range_check', 'pedersen'],
+        ['output', 'pedersen', 'range_check', 'ecdsa'],
+        false,
+      ],
+    ])(
+      'should correctly find subsequences',
+      (subsequence, sequence, expected) => {
+        expect(isSubsequence(subsequence, sequence)).toEqual(expected);
+      }
+    );
+  });
+});

--- a/src/runners/layout.test.ts
+++ b/src/runners/layout.test.ts
@@ -139,6 +139,7 @@ describe('layouts', () => {
 
   describe('isSubsequence', () => {
     test.each([
+      [[], ['output', 'pedersen', 'range_check'], true],
       [
         ['output', 'pedersen', 'range_check'],
         ['output', 'pedersen', 'range_check', 'ecdsa'],

--- a/src/runners/layout.test.ts
+++ b/src/runners/layout.test.ts
@@ -16,6 +16,7 @@ describe('layouts', () => {
       expect(plain.dilutedPool).toBeUndefined();
       expect(plain.ratios).toBeUndefined();
     });
+
     test.each([
       [
         'small',

--- a/src/runners/layout.ts
+++ b/src/runners/layout.ts
@@ -125,6 +125,8 @@ export const layouts: { [key: string]: Layout } = {
   },
 };
 
+export const ALL_LAYOUTS = Object.keys(layouts);
+
 export function isSubsequence(
   subsequence: string[],
   sequence: string[]

--- a/src/runners/layout.ts
+++ b/src/runners/layout.ts
@@ -11,11 +11,13 @@ export type DilutedPool = {
 /**
  * Layout provides a configuration when generating a proof
  * - Builtins: List of available builtins.
- *   segment_arena, gas_builtin and system are not proven.
  * - rcUnits: Range Check Units.
  * - publicMemoryFraction: The ratios total memory cells over public memory cells.
  * - dilutedPool: The diluted pool, used for additionnal checks on Bitwise & Keccak
  * - ratios: Dictionnary mapping each builtin name to its ratio.
+ *
+ * NOTE: The builtins `segment_arena`, `gas_builtin` and `system` which can be found
+ * in the program builtins are not part of the layouts because they're not proven as such.
  *
  * NOTE: A ratio defines the number of steps over the number of builtin instances.
  * For every ratio steps, we have one instance.

--- a/src/runners/layout.ts
+++ b/src/runners/layout.ts
@@ -1,0 +1,144 @@
+export type DilutedPool = {
+  unitsPerStep: number;
+  spacing: number;
+  nBits: number;
+};
+
+export type Layout = {
+  builtins: string[];
+  rcUnits: number;
+  publicMemoryFraction: number;
+  dilutedPool?: DilutedPool;
+};
+
+export const DEFAULT_DILUTED_POOL: DilutedPool = {
+  unitsPerStep: 16,
+  spacing: 4,
+  nBits: 16,
+};
+
+export const layouts: { [key: string]: Layout } = {
+  plain: {
+    builtins: [],
+    rcUnits: 16,
+    publicMemoryFraction: 4,
+  },
+  small: {
+    builtins: ['output', 'pedersen', 'range_check', 'ecdsa'],
+    rcUnits: 16,
+    publicMemoryFraction: 4,
+  },
+  dex: {
+    builtins: ['output', 'pedersen', 'range_check', 'ecdsa'],
+    rcUnits: 4,
+    publicMemoryFraction: 4,
+  },
+  recursive: {
+    builtins: ['output', 'pedersen', 'range_check', 'bitwise'],
+    rcUnits: 4,
+    publicMemoryFraction: 8,
+    dilutedPool: DEFAULT_DILUTED_POOL,
+  },
+  starknet: {
+    builtins: [
+      'output',
+      'pedersen',
+      'range_check',
+      'ecdsa',
+      'bitwise',
+      'ec_op',
+      'poseidon',
+    ],
+    rcUnits: 4,
+    publicMemoryFraction: 8,
+    dilutedPool: {
+      unitsPerStep: 2,
+      spacing: 4,
+      nBits: 16,
+    },
+  },
+  starknet_with_keccak: {
+    builtins: [
+      'output',
+      'pedersen',
+      'range_check',
+      'ecdsa',
+      'bitwise',
+      'ec_op',
+      'keccak',
+      'poseidon',
+    ],
+    rcUnits: 4,
+    publicMemoryFraction: 8,
+    dilutedPool: DEFAULT_DILUTED_POOL,
+  },
+  recursive_large_output: {
+    builtins: ['output', 'pedersen', 'range_check', 'bitwise', 'poseidon'],
+    rcUnits: 4,
+    publicMemoryFraction: 8,
+    dilutedPool: DEFAULT_DILUTED_POOL,
+  },
+  recursive_with_poseidon: {
+    builtins: ['output', 'pedersen', 'range_check', 'bitwise', 'poseidon'],
+    rcUnits: 4,
+    publicMemoryFraction: 8,
+    dilutedPool: {
+      unitsPerStep: 8,
+      spacing: 4,
+      nBits: 16,
+    },
+  },
+  all_cairo: {
+    builtins: [
+      'output',
+      'pedersen',
+      'range_check',
+      'ecdsa',
+      'bitwise',
+      'ec_op',
+      'keccak',
+      'poseidon',
+      'range_check96',
+    ],
+    rcUnits: 4,
+    publicMemoryFraction: 8,
+    dilutedPool: DEFAULT_DILUTED_POOL,
+  },
+  all_solidity: {
+    builtins: [
+      'output',
+      'pedersen',
+      'range_check',
+      'ecdsa',
+      'bitwise',
+      'ec_op',
+    ],
+    rcUnits: 8,
+    publicMemoryFraction: 8,
+    dilutedPool: DEFAULT_DILUTED_POOL,
+  },
+  dynamic: {
+    builtins: ['output'],
+    rcUnits: 16,
+    publicMemoryFraction: 8,
+    dilutedPool: DEFAULT_DILUTED_POOL,
+  },
+};
+
+export function isSubsequence(
+  subsequence: string[],
+  sequence: string[]
+): boolean {
+  return subsequence.reduce(
+    (acc, str) => {
+      const index = acc.sequence.findIndex((value) => value === str);
+      if (index === -1) {
+        acc.found = false;
+      } else {
+        acc.sequence = acc.sequence.slice(index + 1);
+      }
+      return acc;
+    },
+    { sequence, found: true }
+  ).found;
+}

--- a/src/runners/layout.ts
+++ b/src/runners/layout.ts
@@ -131,16 +131,10 @@ export function isSubsequence(
   subsequence: string[],
   sequence: string[]
 ): boolean {
-  return subsequence.reduce(
-    (acc, str) => {
-      const index = acc.sequence.findIndex((value) => value === str);
-      if (index === -1) {
-        acc.found = false;
-      } else {
-        acc.sequence = acc.sequence.slice(index + 1);
-      }
-      return acc;
-    },
-    { sequence, found: true }
-  ).found;
+  if (!subsequence.length) return true;
+
+  const index = sequence.findIndex((name) => name === subsequence[0]);
+  if (index === -1) return false;
+
+  return isSubsequence(subsequence.slice(1), sequence.slice(index + 1));
 }

--- a/src/runners/layout.ts
+++ b/src/runners/layout.ts
@@ -1,14 +1,32 @@
+/**
+ *  Used for additionnal checks in Proof Mode
+ * when using Bitwise and Keccak builtins
+ */
 export type DilutedPool = {
   unitsPerStep: number;
   spacing: number;
   nBits: number;
 };
 
+/**
+ * Layout provides a configuration when generating a proof
+ * - Builtins: List of available builtins.
+ *   segment_arena, gas_builtin and system are not proven.
+ * - rcUnits: Range Check Units.
+ * - publicMemoryFraction: The ratios total memory cells over public memory cells.
+ * - dilutedPool: The diluted pool, used for additionnal checks on Bitwise & Keccak
+ * - ratios: Dictionnary mapping each builtin name to its ratio.
+ *
+ * NOTE: A ratio defines the number of steps over the number of builtin instances.
+ * For every ratio steps, we have one instance.
+ * An empty ratio represents a dynamic ratio.
+ */
 export type Layout = {
   builtins: string[];
   rcUnits: number;
   publicMemoryFraction: number;
   dilutedPool?: DilutedPool;
+  ratios?: { [key: string]: number };
 };
 
 export const DEFAULT_DILUTED_POOL: DilutedPool = {
@@ -27,17 +45,32 @@ export const layouts: { [key: string]: Layout } = {
     builtins: ['output', 'pedersen', 'range_check', 'ecdsa'],
     rcUnits: 16,
     publicMemoryFraction: 4,
+    ratios: {
+      pedersen: 8,
+      range_check: 8,
+      ecdsa: 512,
+    },
   },
   dex: {
     builtins: ['output', 'pedersen', 'range_check', 'ecdsa'],
     rcUnits: 4,
     publicMemoryFraction: 4,
+    ratios: {
+      pedersen: 8,
+      range_check: 8,
+      ecdsa: 512,
+    },
   },
   recursive: {
     builtins: ['output', 'pedersen', 'range_check', 'bitwise'],
     rcUnits: 4,
     publicMemoryFraction: 8,
     dilutedPool: DEFAULT_DILUTED_POOL,
+    ratios: {
+      pedersen: 128,
+      range_check: 8,
+      bitwise: 8,
+    },
   },
   starknet: {
     builtins: [
@@ -56,6 +89,14 @@ export const layouts: { [key: string]: Layout } = {
       spacing: 4,
       nBits: 16,
     },
+    ratios: {
+      pedersen: 32,
+      range_check: 16,
+      ecdsa: 2048,
+      bitwise: 64,
+      ec_op: 1024,
+      poseidon: 32,
+    },
   },
   starknet_with_keccak: {
     builtins: [
@@ -71,12 +112,27 @@ export const layouts: { [key: string]: Layout } = {
     rcUnits: 4,
     publicMemoryFraction: 8,
     dilutedPool: DEFAULT_DILUTED_POOL,
+    ratios: {
+      pedersen: 32,
+      range_check: 16,
+      ecdsa: 2048,
+      bitwise: 64,
+      ec_op: 1024,
+      keccak: 2048,
+      poseidon: 32,
+    },
   },
   recursive_large_output: {
     builtins: ['output', 'pedersen', 'range_check', 'bitwise', 'poseidon'],
     rcUnits: 4,
     publicMemoryFraction: 8,
     dilutedPool: DEFAULT_DILUTED_POOL,
+    ratios: {
+      pedersen: 128,
+      range_check: 8,
+      bitwise: 8,
+      poseidon: 8,
+    },
   },
   recursive_with_poseidon: {
     builtins: ['output', 'pedersen', 'range_check', 'bitwise', 'poseidon'],
@@ -86,6 +142,12 @@ export const layouts: { [key: string]: Layout } = {
       unitsPerStep: 8,
       spacing: 4,
       nBits: 16,
+    },
+    ratios: {
+      pedersen: 256,
+      range_check: 16,
+      bitwise: 16,
+      poseidon: 64,
     },
   },
   all_cairo: {
@@ -103,6 +165,16 @@ export const layouts: { [key: string]: Layout } = {
     rcUnits: 4,
     publicMemoryFraction: 8,
     dilutedPool: DEFAULT_DILUTED_POOL,
+    ratios: {
+      pedersen: 256,
+      range_check: 8,
+      ecdsa: 2048,
+      bitwise: 16,
+      ec_op: 1024,
+      keccak: 2048,
+      poseidon: 256,
+      range_check96: 8,
+    },
   },
   all_solidity: {
     builtins: [
@@ -116,17 +188,33 @@ export const layouts: { [key: string]: Layout } = {
     rcUnits: 8,
     publicMemoryFraction: 8,
     dilutedPool: DEFAULT_DILUTED_POOL,
+    ratios: {
+      pedersen: 8,
+      range_check: 8,
+      ecdsa: 512,
+      bitwise: 256,
+      ec_op: 256,
+    },
   },
   dynamic: {
-    builtins: ['output'],
+    builtins: [
+      'output',
+      'pedersen',
+      'range_check',
+      'ecdsa',
+      'bitwise',
+      'ec_op',
+    ],
     rcUnits: 16,
     publicMemoryFraction: 8,
     dilutedPool: DEFAULT_DILUTED_POOL,
+    ratios: {},
   },
 };
 
 export const ALL_LAYOUTS = Object.keys(layouts);
 
+/** Return whether `subsequence` is a subsequence of `sequence` */
 export function isSubsequence(
   subsequence: string[],
   sequence: string[]

--- a/src/runners/layout.ts
+++ b/src/runners/layout.ts
@@ -35,6 +35,20 @@ export const DEFAULT_DILUTED_POOL: DilutedPool = {
   nBits: 16,
 };
 
+/**
+ * Dictionnary containing all the available layouts:
+ * - plain
+ * - small
+ * - dex
+ * - recursive
+ * - starknet
+ * - starknet_with_keccak
+ * - recursive_large_output
+ * - recursive_with_poseidon
+ * - all_cairo
+ * - all_solidity
+ * - dynamic
+ */
 export const layouts: { [key: string]: Layout } = {
   plain: {
     builtins: [],
@@ -212,6 +226,7 @@ export const layouts: { [key: string]: Layout } = {
   },
 };
 
+/** Array of all the available layouts name */
 export const ALL_LAYOUTS = Object.keys(layouts);
 
 /** Return whether `subsequence` is a subsequence of `sequence` */

--- a/src/scripts/run.ts
+++ b/src/scripts/run.ts
@@ -31,7 +31,7 @@ export const run = (
 
     if (silent) consola.level = LogLevels.silent;
 
-    if (ALL_LAYOUTS.findIndex((name) => layout == name) === -1) {
+    if (!ALL_LAYOUTS.includes(layout)) {
       consola.error(
         `Layout "${layout}" is not a valid layout.
 Use one from {${ALL_LAYOUTS.join(', ')}}`

--- a/src/scripts/run.ts
+++ b/src/scripts/run.ts
@@ -5,20 +5,7 @@ import { ConsolaInstance, LogLevels } from 'consola';
 import { TraceEntry } from 'vm/virtualMachine';
 import { parseProgram } from 'vm/program';
 import { CairoRunner, RunOptions } from 'runners/cairoRunner';
-
-const layoutNames = [
-  'plain',
-  'small',
-  'dex',
-  'recursive',
-  'starknet',
-  'starknet_with_keccak',
-  'recursive_large_output',
-  'recursive_with_poseidon',
-  'all_cairo',
-  'all_solidity',
-  'dynamic',
-];
+import { ALL_LAYOUTS } from 'runners/layout';
 
 export const run = (
   path: string,
@@ -44,10 +31,10 @@ export const run = (
 
     if (silent) consola.level = LogLevels.silent;
 
-    if (layoutNames.findIndex((name) => layout == name) === -1) {
+    if (ALL_LAYOUTS.findIndex((name) => layout == name) === -1) {
       consola.error(
         `Layout "${layout}" is not a valid layout.
-Use one from {${layoutNames.join(', ')}}`
+Use one from {${ALL_LAYOUTS.join(', ')}}`
       );
       process.exit(1);
     }

--- a/src/scripts/run.ts
+++ b/src/scripts/run.ts
@@ -6,6 +6,20 @@ import { TraceEntry } from 'vm/virtualMachine';
 import { parseProgram } from 'vm/program';
 import { CairoRunner, RunOptions } from 'runners/cairoRunner';
 
+const layoutNames = [
+  'plain',
+  'small',
+  'dex',
+  'recursive',
+  'starknet',
+  'starknet_with_keccak',
+  'recursive_large_output',
+  'recursive_with_poseidon',
+  'all_cairo',
+  'all_solidity',
+  'dynamic',
+];
+
 export const run = (
   path: string,
   options: any,
@@ -16,6 +30,7 @@ export const run = (
   try {
     const {
       silent,
+      layout,
       fn,
       relocate,
       offset,
@@ -29,12 +44,20 @@ export const run = (
 
     if (silent) consola.level = LogLevels.silent;
 
+    if (layoutNames.findIndex((name) => layout == name) === -1) {
+      consola.error(
+        `Layout "${layout}" is not a valid layout.
+Use one from {${layoutNames.join(', ')}}`
+      );
+      process.exit(1);
+    }
+
     if (
       (!relocate && !!offset) ||
       (!relocate && exportMemory) ||
       (!relocate && printRelocatedMemory)
     ) {
-      consola.log(
+      consola.error(
         "option '--no-relocate' cannot be used with options '--offset <OFFSET>', '--export-memory <MEMORY_FILENAME>' or '--print-relocated-memory'"
       );
       process.exit(1);

--- a/src/scripts/run.ts
+++ b/src/scripts/run.ts
@@ -68,7 +68,7 @@ Use one from {${layoutNames.join(', ')}}`
     const file = fs.readFileSync(String(path), 'utf-8');
 
     const program = parseProgram(file);
-    runner = CairoRunner.fromProgram(program, fn);
+    runner = CairoRunner.fromProgram(program, layout, fn);
     const config: RunOptions = { relocate: relocate, offset: offset };
     runner.run(config);
     consola.success('Execution finished!');


### PR DESCRIPTION
Closes #89 

- Add builtins validation against the layout.
- Add a flag `-l, --layout` in the CLI
- `ratio` values which were living in the BuiltinInstanceDef in other implementations are refactored into the Layout as the `ratios` dictionnary.
- `getBuiltinSegment` method which allows extracting any memory segment which represents a builtin. It needs to know which builtins have been initialized by the run.
- `builtins` attribute for CairoRunner, needed for `getBuiltinSegment`

NOTE: The `builtins` attribute currently stores the builtins used by the called program entrypoint (`program.builtins`). It works well in ExecutionMode as only the builtins in the program are used. However, in Proof Mode, all the builtins from the chosen layout are initialized, that won't be represented by the current `builtins` attribute.
When introducting the proof mode, this `builtins` attribute initialization should be refactored to take this into account.