### PR TITLE
feat: update CI to run all the available Cairo and Cairo Zero programs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,3 +81,6 @@ jobs:
 
       - name: Run tests
         run: bun install && bun test
+
+      - name: Run all Cairo Zero & Cairo programs
+        run: make run-all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,5 +82,8 @@ jobs:
       - name: Run tests
         run: bun install && bun test
 
+      - name: Setup Cairo VM TS CLI
+        run: bun link
+
       - name: Run all Cairo Zero & Cairo programs
         run: make run-all

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ run-all: $(VALID_COMPILED_CAIRO_0_FILES) $(COMPILED_CAIRO_FILES)
 		for file in $$failed_tests; do \
 			echo $$file; \
 		done; \
+		exit 1; \
 	else \
 		echo "All $$passed_tests_ctr tests passed."; \
 	fi


### PR DESCRIPTION
Useful to verify in the CI that a newly added Cairo files is executed (integration test).

A next iteration would be adding diff-testing to the CI (can be done for Cairo Zero programs but not Cairo programs as of now)