### PR TITLE
Typo Update builtins.ts

### DIFF
--- a/src/errors/builtins.ts
+++ b/src/errors/builtins.ts
@@ -4,11 +4,11 @@ import { Felt } from 'primitives/felt';
 /** Errors related to builtins */
 class BuiltinError extends Error {}
 
-/** Value cannot be infered from undefined cell value */
+/** Value cannot be inferred from undefined cell value */
 export class UndefinedValue extends BuiltinError {
   constructor(offset: number) {
     super(
-      `Value cannot be infered from undefined cell value at offset ${offset}`
+      `Value cannot be inferred from undefined cell value at offset ${offset}`
     );
   }
 }


### PR DESCRIPTION
### Description
The word "infered" in the `UndefinedValue` class constructor was corrected to "inferred".

**Original Code**:  
```javascript
Value cannot be infered from undefined cell value at offset ${offset}
```

**Corrected Code**:  
```javascript
Value cannot be inferred from undefined cell value at offset ${offset}
```

**Reason for Change**:  
The word "infered" was mistakenly used, but the correct past participle form of the verb "infer" is **"inferred"**, not "infered." This is an important grammatical rule and fixing it ensures that the message is both technically accurate and professionally written.

### Impact
This change improves the clarity and correctness of the error message. Although the error may not affect the functionality of the code, it is important for maintaining proper grammar and ensuring the readability of messages in the codebase, especially when they are exposed to users or developers for debugging purposes.
